### PR TITLE
Staffelplan Preview Fixes für WS 17/18

### DIFF
--- a/app/services/ScheduleService.scala
+++ b/app/services/ScheduleService.scala
@@ -35,7 +35,7 @@ trait ScheduleServiceLike {
 
 trait ScheduleGenesisServiceLike {
   def generate(timetable: Timetable, groups: Set[Group], assignmentPlan: AssignmentPlan, semester: Semester, competitive: Vector[ScheduleG], p: Option[Int] = None, g: Option[Int] = None, e: Option[Int] = None): (Gen[ScheduleG, Conflict, Int], Int)
-  def competitive(labwork: Option[LabworkAtom], all: Set[ScheduleAtom]): Set[ScheduleG]
+  def competitive(labwork: Option[LabworkAtom], all: Set[ScheduleAtom], concernIndex: Boolean): Set[ScheduleG]
 }
 
 object ScheduleService {
@@ -193,10 +193,9 @@ class ScheduleService(val pops: Int, val gens: Int, val elite: Int, private val 
     } map (_ * conflicts.count(_.isDefined))
   }
 
-  override def competitive(labwork: Option[LabworkAtom], all: Set[ScheduleAtom]): Set[ScheduleG] = {
+  override def competitive(labwork: Option[LabworkAtom], all: Set[ScheduleAtom], concernIndex: Boolean): Set[ScheduleG] = {
     labwork.fold(Set.empty[ScheduleG]) { item =>
-      val filtered = all
-        .filter(_.labwork.course.semesterIndex == item.course.semesterIndex)
+      val filtered = (if (concernIndex) all.filter(_.labwork.course.semesterIndex == item.course.semesterIndex) else all)
         .filter(_.labwork.semester.id == item.semester.id)
         .filter(_.labwork.degree.id == item.degree.id)
         .filterNot(_.labwork.id == item.id)

--- a/conf/routes
+++ b/conf/routes
@@ -186,6 +186,7 @@ GET           /courses/:c/labworks/:l/reportCardEvaluations                     
 GET           /courses/:c/labworks/:l/atomic/reportCardEvaluations                    controllers.ReportCardEvaluationController.allAtomicFrom(c, l)
 GET           /courses/:c/labworks/:l/reportCardEvaluations/preview                   controllers.ReportCardEvaluationController.preview(c, l)
 GET           /courses/:c/labworks/:l/atomic/reportCardEvaluations/preview            controllers.ReportCardEvaluationController.previewAtomic(c, l)
+DELETE        /courses/:c/labworks/:l/reportCardEvaluations                           controllers.ReportCardEvaluationController.deleteFrom(c, l)
 
 # AssignmentPlan
 POST          /courses/:course/assignmentPlans                                        controllers.AssignmentPlanCRUDController.createFrom(course)


### PR DESCRIPTION
**Achtung**
Das sind Hot-Fixes, welche im [neuen Backend](https://github.com/THK-ADV/lwm-reloaded/tree/LWM-Postgres) sinnvoll gelöst werden sollen.

* Index als Query-Parameter für `GET /courses/:c/labworks/:l/schedules/preview` steuert ob der Semester Index berücksichtigt werden soll oder nicht. 1 -> berücksichtigen, 0 -> ignorieren. 0 führt selbstverständlich zu mehr Konflikten im Staffelplan
* Gruppen, die zwangsläufig bei jeder Preview des Staffelplans erstellt werden, werden bei einer erneuten Preview gelöscht, wenn der Staffelplan bei der vorherigen Preview nicht erstellt worden ist
* Delete für ReportCardEvaluations