### PR TITLE
make slick more as a first class citizen in play

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,27 +1,21 @@
-import java.io.File
-
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.ActorRef
 import auth.{KeycloakAuthorization, OAuthAuthorization}
+import com.google.inject.AbstractModule
 import com.google.inject.name.Names
-import com.google.inject.{AbstractModule, Provides}
-import com.typesafe.config.ConfigFactory
 import dao._
-import javax.inject.{Named, Singleton}
-import org.keycloak.adapters.{KeycloakDeployment, KeycloakDeploymentBuilder}
-import play.api.{Configuration, Play}
+import di._
+import javax.inject.Singleton
+import org.keycloak.adapters.KeycloakDeployment
+import play.api.{Configuration, Environment}
 import services.backup.{BackupService, BackupServiceActor, PSQLBackupService}
 import services.blacklist.{BlacklistService, BlacklistServiceImpl}
-import services.{ActorScheduler, ScheduleService, ScheduleServiceImpl, Webservice}
-import slick.jdbc.PostgresProfile
+import services.{ActorScheduler, ScheduleService, Webservice}
 import slick.jdbc.PostgresProfile.api._
 
-import scala.util.Try
-
-class Module extends AbstractModule {
-
-  import Module._
+class Module(environment: Environment, config: Configuration) extends AbstractModule {
 
   override def configure(): Unit = {
+    bindDatabase()
     bindDaos()
     bindServices()
     bindActors()
@@ -32,6 +26,9 @@ class Module extends AbstractModule {
     bind(classOf[BlacklistService]).to(classOf[BlacklistServiceImpl]).in(classOf[Singleton])
     bind(classOf[OAuthAuthorization]).to(classOf[KeycloakAuthorization]).in(classOf[Singleton])
     bind(classOf[BackupService]).to(classOf[PSQLBackupService]).in(classOf[Singleton])
+
+    bind(classOf[ScheduleService]).toProvider(classOf[ScheduleServiceProvider])
+    bind(classOf[KeycloakDeployment]).toProvider(classOf[KeycloakDeploymentProvider])
   }
 
   private def bindDaos(): Unit = {
@@ -62,6 +59,9 @@ class Module extends AbstractModule {
   private def bindActors(): Unit = {
     bind(classOf[ActorScheduler]).asEagerSingleton()
 
+    bind(classOf[ActorRef])
+      .annotatedWith(classOf[BackupServiceActorAnnotation])
+      .toProvider(classOf[BackupServiceProvider])
     bind(classOf[Any])
       .annotatedWith(Names.named("backupMessage"))
       .toInstance(BackupServiceActor.BackupRequestAsync)
@@ -70,48 +70,10 @@ class Module extends AbstractModule {
       .to(config("lwm.backup.localTime") getOrElse "")
   }
 
-  @Provides
-  @Singleton
-  private def databaseProvider(): PostgresProfile.backend.Database = Database forConfig "database"
-
-  @Provides
-  @Singleton
-  private def keycloakDeploymentProvider(): KeycloakDeployment = KeycloakDeploymentBuilder.build(
-    Play.getClass.getResourceAsStream("/keycloak.json")
-  )
-
-  @Provides
-  @Singleton
-  private def scheduleServiceProvider(): ScheduleService = {
-    val pops = _config getOptional[Int] "lwm.schedule.populations" getOrElse 20
-    val gens = _config getOptional[Int] "lwm.schedule.generations" getOrElse 100
-    val elites = _config getOptional[Int] "lwm.schedule.elites" getOrElse 10
-
-    new ScheduleServiceImpl(pops, gens, elites)
+  private def bindDatabase(): Unit = {
+    bind(classOf[Database]).toProvider(classOf[DatabaseProvider])
+    bind(classOf[DatabaseCloseHook]).asEagerSingleton()
   }
 
-  @Provides
-  @Singleton
-  @Named("backupActor")
-  private def backupServiceActor(system: ActorSystem, backupService: BackupService): ActorRef = {
-    val file = for {
-      filePath <- nonEmptyConfig("lwm.backup.path")
-      file <- Try(new File(filePath)).toOption
-      _ <- Try(file.mkdirs).toOption
-    } yield file
-
-    /* throwing providers seems to be complicated to support.
-    thus, optionality has to be handled internally.
-    see https://github.com/google/guice/wiki/ThrowingProviders */
-
-    system.actorOf(Props(new BackupServiceActor(backupService, file)))
-  }
-}
-
-object Module {
-  private lazy val _config = Configuration(ConfigFactory.defaultApplication.resolve)
-
-  private def nonEmptyConfig(name: String): Option[String] = config(name) filter (_.nonEmpty)
-
-  private def config(name: String): Option[String] = _config getOptional[String] name
+  private def config(name: String): Option[String] = config getOptional[String] name
 }

--- a/app/controllers/HomepageController.scala
+++ b/app/controllers/HomepageController.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.Json
 import play.api.mvc._
 
 @Singleton
-class HomepageController @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
+class HomepageController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
 
   def index = Action {
     Ok(Json.obj(

--- a/app/dao/AuthorityDao.scala
+++ b/app/dao/AuthorityDao.scala
@@ -170,4 +170,4 @@ trait AuthorityDao extends AbstractDao[AuthorityTable, AuthorityDb, AuthorityLik
   }
 }
 
-final class AuthorityDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val roleDao: RoleDao, val executionContext: ExecutionContext) extends AuthorityDao
+final class AuthorityDaoImpl @Inject()(val db: Database, val roleDao: RoleDao, val executionContext: ExecutionContext) extends AuthorityDao

--- a/app/dao/BlacklistDao.scala
+++ b/app/dao/BlacklistDao.scala
@@ -66,4 +66,4 @@ trait BlacklistDao extends AbstractDao[BlacklistTable, BlacklistDb, Blacklist] {
   }
 }
 
-final class BlacklistDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends BlacklistDao
+final class BlacklistDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends BlacklistDao

--- a/app/dao/CourseDao.scala
+++ b/app/dao/CourseDao.scala
@@ -51,5 +51,5 @@ trait CourseDao extends AbstractDao[CourseTable, CourseDb, CourseLike] {
   }
 }
 
-final class CourseDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends CourseDao
+final class CourseDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends CourseDao
 

--- a/app/dao/DashboardDao.scala
+++ b/app/dao/DashboardDao.scala
@@ -2,17 +2,15 @@ package dao
 
 import java.util.UUID
 
+import dao.helper.Core
 import javax.inject.Inject
 import models.{AuthorityAtom, EmployeeDashboard, Semester, Student, StudentDashboard}
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import utils.LwmDateTime._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait DashboardDao { // TODO check and refactor
-
-  protected implicit def executionContext: ExecutionContext
+trait DashboardDao extends Core { // TODO check and refactor
 
   def dashboard(systemId: String)(atomic: Boolean, validOnly: Boolean, sinceLastModified: Option[String]) = {
     semesterDao.get(List(SemesterCurrentFilter), atomic, validOnly, sinceLastModified) map (_.toList) flatMap {
@@ -46,8 +44,6 @@ trait DashboardDao { // TODO check and refactor
     scheduleEntries <- scheduleEntryDao.get(scheduleEntryFilter, atomic, validOnly, sinceLastModified)
   } yield EmployeeDashboard(semester, courses, scheduleEntries)
 
-  protected def db: PostgresProfile.backend.Database
-
   protected def userDao: UserDao
 
   protected def semesterDao: SemesterDao
@@ -70,7 +66,7 @@ trait DashboardDao { // TODO check and refactor
 }
 
 final class DashboardDaoImpl @Inject()(
-  val db: PostgresProfile.backend.Database,
+  val db: Database,
   val userDao: UserDao,
   val semesterDao: SemesterDao,
   val labworkDao: LabworkDao,

--- a/app/dao/DegreeDao.scala
+++ b/app/dao/DegreeDao.scala
@@ -39,4 +39,4 @@ trait DegreeDao extends AbstractDao[DegreeTable, DegreeDb, Degree] {
   override protected def toUniqueEntity(query: Query[DegreeTable, DegreeDb, Seq]): Future[Traversable[Degree]] = db.run(query.result.map(_.map(_.toUniqueEntity)))
 }
 
-final class DegreeDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends DegreeDao
+final class DegreeDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends DegreeDao

--- a/app/dao/LabworkApplicationDao.scala
+++ b/app/dao/LabworkApplicationDao.scala
@@ -99,7 +99,7 @@ trait LabworkApplicationDao extends AbstractDao[LabworkApplicationTable, Labwork
     }))
   }
 
-  override protected def databaseExpander: Option[DatabaseExpander[LabworkApplicationDb]] = Some(new DatabaseExpander[LabworkApplicationDb] {
+  override protected val databaseExpander: Option[DatabaseExpander[LabworkApplicationDb]] = Some(new DatabaseExpander[LabworkApplicationDb] {
     override def expandCreationOf[X <: Effect](entities: LabworkApplicationDb*): jdbc.PostgresProfile.api.DBIOAction[Seq[LabworkApplicationDb], jdbc.PostgresProfile.api.NoStream, Effect.Write with Any] = {
       val friends = entities.flatMap(l => l.friends.map(f => LabworkApplicationFriend(l.id, f)))
 
@@ -120,18 +120,10 @@ trait LabworkApplicationDao extends AbstractDao[LabworkApplicationTable, Labwork
     }
   })
 
-  private lazy val schemas = List(
+  override protected val schemas: List[PostgresProfile.DDL] = List(
     tableQuery.schema,
     lappFriendQuery.schema
   )
-
-  override def createSchema: Future[Unit] = {
-    db.run(DBIO.seq(schemas.map(_.create): _*).transactionally)
-  }
-
-  override def dropSchema: Future[Unit] = {
-    db.run(DBIO.seq(schemas.reverseMap(_.drop): _*).transactionally)
-  }
 
   override def createQuery(entity: LabworkApplicationDb) = { // TODO this is business logic, which normally belongs to a service class
     if (entity.friends.contains(entity.applicant))
@@ -141,4 +133,4 @@ trait LabworkApplicationDao extends AbstractDao[LabworkApplicationTable, Labwork
   }
 }
 
-final class LabworkApplicationDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends LabworkApplicationDao
+final class LabworkApplicationDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends LabworkApplicationDao

--- a/app/dao/LabworkDao.scala
+++ b/app/dao/LabworkDao.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import database.{LabworkDb, LabworkTable, TableFilter}
 import javax.inject.Inject
 import models._
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -79,4 +78,4 @@ trait LabworkDao extends AbstractDao[LabworkTable, LabworkDb, LabworkLike] {
   }
 }
 
-final class LabworkDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends LabworkDao
+final class LabworkDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends LabworkDao

--- a/app/dao/ReportCardEntryTypeDao.scala
+++ b/app/dao/ReportCardEntryTypeDao.scala
@@ -6,7 +6,6 @@ import database.{ReportCardEntryTypeDb, ReportCardEntryTypeTable, TableFilter}
 import javax.inject.Inject
 import models.ReportCardEntryType
 import org.joda.time.DateTime
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.TableQuery
 
@@ -56,4 +55,4 @@ trait ReportCardEntryTypeDao extends AbstractDao[ReportCardEntryTypeTable, Repor
   )
 }
 
-final class ReportCardEntryTypeDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends ReportCardEntryTypeDao
+final class ReportCardEntryTypeDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends ReportCardEntryTypeDao

--- a/app/dao/ReportCardEvaluationDao.scala
+++ b/app/dao/ReportCardEvaluationDao.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import database._
 import javax.inject.Inject
 import models._
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.TableQuery
 import utils.LwmDateTime.SqlTimestampConverter
@@ -85,4 +84,4 @@ trait ReportCardEvaluationDao extends AbstractDao[ReportCardEvaluationTable, Rep
   }
 }
 
-final class ReportCardEvaluationDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends ReportCardEvaluationDao
+final class ReportCardEvaluationDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends ReportCardEvaluationDao

--- a/app/dao/ReportCardEvaluationPatternDao.scala
+++ b/app/dao/ReportCardEvaluationPatternDao.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import database.{ReportCardEvaluationPatternDb, ReportCardEvaluationPatternTable, TableFilter}
 import javax.inject.Inject
 import models.ReportCardEvaluationPattern
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.TableQuery
 
@@ -51,4 +50,4 @@ trait ReportCardEvaluationPatternDao extends AbstractDao[ReportCardEvaluationPat
   }
 }
 
-final class ReportCardEvaluationPatternDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends ReportCardEvaluationPatternDao
+final class ReportCardEvaluationPatternDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends ReportCardEvaluationPatternDao

--- a/app/dao/ReportCardRescheduledDao.scala
+++ b/app/dao/ReportCardRescheduledDao.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import database.{ReportCardRescheduledDb, ReportCardRescheduledTable, TableFilter}
 import javax.inject.Inject
 import models._
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -59,4 +58,4 @@ trait ReportCardRescheduledDao extends AbstractDao[ReportCardRescheduledTable, R
   }
 }
 
-final class ReportCardRescheduledDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends ReportCardRescheduledDao
+final class ReportCardRescheduledDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends ReportCardRescheduledDao

--- a/app/dao/ReportCardRetryDao.scala
+++ b/app/dao/ReportCardRetryDao.scala
@@ -7,7 +7,6 @@ import database._
 import javax.inject.Inject
 import models._
 import slick.jdbc
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.TableQuery
 import utils.LwmDateTime._
@@ -81,7 +80,7 @@ trait ReportCardRetryDao extends AbstractDao[ReportCardRetryTable, ReportCardRet
       existing.reportCardEntry == toUpdate.reportCardEntry
   }
 
-  override protected def databaseExpander: Option[DatabaseExpander[ReportCardRetryDb]] = Some(new DatabaseExpander[ReportCardRetryDb] {
+  override protected val databaseExpander: Option[DatabaseExpander[ReportCardRetryDb]] = Some(new DatabaseExpander[ReportCardRetryDb] {
 
     override def expandCreationOf[E <: Effect](entities: ReportCardRetryDb*): jdbc.PostgresProfile.api.DBIOAction[Seq[ReportCardRetryDb], jdbc.PostgresProfile.api.NoStream, Effect.Write with Any] = for {
       _ <- entryTypeQuery ++= entities.flatMap(_.entryTypes)
@@ -98,4 +97,4 @@ trait ReportCardRetryDao extends AbstractDao[ReportCardRetryTable, ReportCardRet
   })
 }
 
-final class ReportCardRetryDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends ReportCardRetryDao
+final class ReportCardRetryDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends ReportCardRetryDao

--- a/app/dao/RoleDao.scala
+++ b/app/dao/RoleDao.scala
@@ -8,7 +8,6 @@ import javax.inject.Inject
 import models.Role.{EmployeeRole, StudentRole}
 import models._
 import slick.dbio.Effect
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -66,4 +65,4 @@ trait RoleDao extends AbstractDao[RoleTable, RoleDb, Role] {
   }
 }
 
-final class RoleDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends RoleDao
+final class RoleDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends RoleDao

--- a/app/dao/RoomDao.scala
+++ b/app/dao/RoomDao.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import database.{RoomDb, RoomTable, TableFilter}
 import javax.inject.Inject
 import models.Room
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,4 +38,4 @@ trait RoomDao extends AbstractDao[RoomTable, RoomDb, Room] {
   }
 }
 
-final class RoomDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends RoomDao
+final class RoomDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends RoomDao

--- a/app/dao/ScheduleEntryDao.scala
+++ b/app/dao/ScheduleEntryDao.scala
@@ -149,7 +149,7 @@ trait ScheduleEntryDao extends AbstractDao[ScheduleEntryTable, ScheduleEntryDb, 
     db.run(action map transform)
   }
 
-  override protected def databaseExpander: Option[DatabaseExpander[ScheduleEntryDb]] = Some(new DatabaseExpander[ScheduleEntryDb] {
+  override protected val databaseExpander: Option[DatabaseExpander[ScheduleEntryDb]] = Some(new DatabaseExpander[ScheduleEntryDb] {
     override def expandCreationOf[E <: Effect](entities: ScheduleEntryDb*): jdbc.PostgresProfile.api.DBIOAction[Seq[ScheduleEntryDb], jdbc.PostgresProfile.api.NoStream, Effect.Write with Any] = for {
       _ <- scheduleEntrySupervisorQuery ++= entities.flatMap { e =>
         e.supervisor.map(u => ScheduleEntrySupervisor(e.id, u))
@@ -196,19 +196,10 @@ trait ScheduleEntryDao extends AbstractDao[ScheduleEntryTable, ScheduleEntryDb, 
     }
   }
 
-
-  private lazy val schemas = List(
+  override protected val schemas: List[PostgresProfile.DDL] = List(
     tableQuery.schema,
     scheduleEntrySupervisorQuery.schema
   )
-
-  override def createSchema: Future[Unit] = {
-    db.run(DBIO.seq(schemas.map(_.create): _*).transactionally)
-  }
-
-  override def dropSchema: Future[Unit] = {
-    db.run(DBIO.seq(schemas.reverseMap(_.drop): _*).transactionally)
-  }
 }
 
-final class ScheduleEntryDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends ScheduleEntryDao
+final class ScheduleEntryDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends ScheduleEntryDao

--- a/app/dao/SemesterDao.scala
+++ b/app/dao/SemesterDao.scala
@@ -38,6 +38,7 @@ case class SemesterEndFilter(value: String) extends TableFilter[SemesterTable] {
 
 case object SemesterCurrentFilter extends TableFilter[SemesterTable] {
   override def predicate = t => t.start <= value.sqlDateFromMillis && t.end >= value.sqlDateFromMillis
+
   override def value: String = LocalDate.now.stringMillis
 }
 
@@ -72,4 +73,4 @@ trait SemesterDao extends AbstractDao[SemesterTable, SemesterDb, Semester] {
   }
 }
 
-final class SemesterDaoImpl @Inject() (val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends SemesterDao
+final class SemesterDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends SemesterDao

--- a/app/dao/TimetableDao.scala
+++ b/app/dao/TimetableDao.scala
@@ -91,7 +91,7 @@ trait TimetableDao extends AbstractDao[TimetableTable, TimetableDb, TimetableLik
       existing.labwork == toUpdate.labwork
   }
 
-  override protected def databaseExpander: Option[DatabaseExpander[TimetableDb]] = Some(new DatabaseExpander[TimetableDb] {
+  override protected val databaseExpander: Option[DatabaseExpander[TimetableDb]] = Some(new DatabaseExpander[TimetableDb] {
     override def expandCreationOf[X <: Effect](entities: TimetableDb*): jdbc.PostgresProfile.api.DBIOAction[Seq[TimetableDb], jdbc.PostgresProfile.api.NoStream, Effect.Write with Any] = {
       val timetableEntries = entities.flatMap { timetable =>
         timetable.entries.map { entry =>
@@ -124,20 +124,12 @@ trait TimetableDao extends AbstractDao[TimetableTable, TimetableDb, TimetableLik
     } yield c.head
   })
 
-  private lazy val schemas = List(
+  override protected val schemas: List[PostgresProfile.DDL] = List(
     tableQuery.schema,
     timetableBlacklistQuery.schema,
     timetableEntryQuery.schema,
     timetableEntrySupervisorQuery.schema
   )
-
-  override def createSchema: Future[Unit] = {
-    db.run(DBIO.seq(schemas.map(_.create): _*).transactionally)
-  }
-
-  override def dropSchema: Future[Unit] = {
-    db.run(DBIO.seq(schemas.reverseMap(_.drop): _*).transactionally)
-  }
 }
 
-final class TimetableDaoImpl @Inject()(val db: PostgresProfile.backend.Database, val executionContext: ExecutionContext) extends TimetableDao
+final class TimetableDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends TimetableDao

--- a/app/dao/UserDao.scala
+++ b/app/dao/UserDao.scala
@@ -8,7 +8,6 @@ import database.{TableFilter, UserDb, UserTable}
 import javax.inject.Inject
 import models._
 import models.helper._
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.Rep
 
@@ -168,7 +167,7 @@ trait UserDao extends AbstractDao[UserTable, UserDb, User] {
 }
 
 final class UserDaoImpl @Inject()(
-  val db: PostgresProfile.backend.Database,
+  val db: Database,
   val authorityDao: AuthorityDao,
   val degreeDao: DegreeDao,
   val labworkApplicationDao: LabworkApplicationDao,

--- a/app/dao/helper/Accessible.scala
+++ b/app/dao/helper/Accessible.scala
@@ -1,0 +1,12 @@
+package dao.helper
+
+import database.UniqueTable
+import models.UniqueDbEntity
+import slick.jdbc.PostgresProfile
+import slick.jdbc.PostgresProfile.api._
+
+trait Accessible[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity] {
+  protected def tableQuery: TableQuery[T]
+
+  protected def schemas: List[PostgresProfile.SchemaDescription] = List(tableQuery.schema)
+}

--- a/app/dao/helper/Added.scala
+++ b/app/dao/helper/Added.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 import scala.util.Try
 
 trait Added[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity] {
-  self: Core[T, DbModel] =>
+  self: Core with Expandable[DbModel] with Accessible[T, DbModel] =>
 
   protected def existsQuery(entity: DbModel): Query[T, DbModel, Seq]
 

--- a/app/dao/helper/Core.scala
+++ b/app/dao/helper/Core.scala
@@ -1,18 +1,11 @@
 package dao.helper
 
-import database.UniqueTable
-import models.UniqueDbEntity
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.ExecutionContext
 
-trait Core[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity] {
-  protected def db: PostgresProfile.backend.Database
-
-  protected def tableQuery: TableQuery[T]
-
-  protected def databaseExpander: Option[DatabaseExpander[DbModel]] = None
+trait Core {
+  protected def db: Database
 
   protected implicit def executionContext: ExecutionContext
 }

--- a/app/dao/helper/Expandable.scala
+++ b/app/dao/helper/Expandable.scala
@@ -1,0 +1,7 @@
+package dao.helper
+
+import models.UniqueDbEntity
+
+trait Expandable[DbModel <: UniqueDbEntity] {
+  protected def databaseExpander: Option[DatabaseExpander[DbModel]] = None
+}

--- a/app/dao/helper/Removed.scala
+++ b/app/dao/helper/Removed.scala
@@ -14,7 +14,7 @@ import utils.LwmDateTime.DateTimeConverter
 import scala.concurrent.Future
 
 trait Removed[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity] {
-  self: Core[T, DbModel] =>
+  self: Core with Expandable[DbModel] with Accessible[T, DbModel] =>
 
   final def delete(entity: DbModel): Future[DbModel] = delete(entity.id)
 

--- a/app/dao/helper/Retrieved.scala
+++ b/app/dao/helper/Retrieved.scala
@@ -12,7 +12,7 @@ import scala.collection.Traversable
 import scala.concurrent.Future
 
 trait Retrieved[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity, LwmModel <: UniqueEntity] {
-  self: Core[T, DbModel] =>
+  self: Core with Accessible[T, DbModel] =>
 
   protected def toAtomic(query: Query[T, DbModel, Seq]): Future[Traversable[LwmModel]]
 

--- a/app/dao/helper/Updated.scala
+++ b/app/dao/helper/Updated.scala
@@ -11,7 +11,7 @@ import utils.LwmDateTime.DateTimeConverter
 import scala.concurrent.Future
 
 trait Updated[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity] {
-  self: Core[T, DbModel] =>
+  self: Core with Expandable[DbModel] with Accessible[T, DbModel] =>
 
   protected def shouldUpdate(existing: DbModel, toUpdate: DbModel): Boolean
 

--- a/app/di/BackupServiceActorAnnotation.java
+++ b/app/di/BackupServiceActorAnnotation.java
@@ -1,0 +1,14 @@
+package di;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@BindingAnnotation
+public @interface BackupServiceActorAnnotation {
+}

--- a/app/di/BackupServiceProvider.scala
+++ b/app/di/BackupServiceProvider.scala
@@ -1,0 +1,30 @@
+package di
+
+import java.io.File
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+import javax.inject.{Inject, Provider, Singleton}
+import play.api.Configuration
+import services.backup.{BackupService, BackupServiceActor}
+
+import scala.util.Try
+
+@Singleton
+class BackupServiceProvider @Inject()(system: ActorSystem, backupService: BackupService, config: Configuration) extends Provider[ActorRef] {
+
+  lazy val get = {
+    def nonEmptyConfig(name: String): Option[String] = (config getOptional[String] name) filter (_.nonEmpty)
+
+    val file = for {
+      filePath <- nonEmptyConfig("lwm.backup.path")
+      file <- Try(new File(filePath)).toOption
+      _ <- Try(file.mkdirs).toOption
+    } yield file
+
+    /* throwing providers seems to be complicated to support.
+    thus, optionality has to be handled internally.
+    see https://github.com/google/guice/wiki/ThrowingProviders */
+
+    system.actorOf(Props(new BackupServiceActor(backupService, file)))
+  }
+}

--- a/app/di/DatabaseCloseHook.scala
+++ b/app/di/DatabaseCloseHook.scala
@@ -1,0 +1,14 @@
+package di
+
+import javax.inject.Inject
+import play.api.inject.ApplicationLifecycle
+import slick.jdbc.PostgresProfile.api._
+
+import scala.concurrent.Future
+
+/** Closes database connections safely.  Important on dev restart. */
+class DatabaseCloseHook @Inject()(val database: Database, lifecycle: ApplicationLifecycle) {
+  lifecycle.addStopHook { () =>
+    Future.successful(database.close()) // TODO ensure that there is only one instance of Database
+  }
+}

--- a/app/di/DatabaseProvider.scala
+++ b/app/di/DatabaseProvider.scala
@@ -1,0 +1,10 @@
+package di
+
+import com.typesafe.config.Config
+import javax.inject.{Inject, Provider, Singleton}
+import slick.jdbc.PostgresProfile.api._
+
+@Singleton
+class DatabaseProvider @Inject()(config: Config) extends Provider[Database] {
+  lazy val get = Database.forConfig("database", config)
+}

--- a/app/di/KeycloakDeploymentProvider.scala
+++ b/app/di/KeycloakDeploymentProvider.scala
@@ -1,0 +1,12 @@
+package di
+
+import javax.inject.{Provider, Singleton}
+import org.keycloak.adapters.{KeycloakDeployment, KeycloakDeploymentBuilder}
+import play.api.Play
+
+@Singleton
+class KeycloakDeploymentProvider extends Provider[KeycloakDeployment] {
+  lazy val get = KeycloakDeploymentBuilder.build(
+    Play.getClass.getResourceAsStream("/keycloak.json")
+  )
+}

--- a/app/di/ScheduleServiceProvider.scala
+++ b/app/di/ScheduleServiceProvider.scala
@@ -1,0 +1,16 @@
+package di
+
+import javax.inject.{Inject, Provider, Singleton}
+import play.api.Configuration
+import services.{ScheduleService, ScheduleServiceImpl}
+
+@Singleton
+class ScheduleServiceProvider @Inject()(config: Configuration) extends Provider[ScheduleService] {
+  lazy val get = {
+    val pops = config getOptional[Int] "lwm.schedule.populations" getOrElse 20
+    val gens = config getOptional[Int] "lwm.schedule.generations" getOrElse 100
+    val elites = config getOptional[Int] "lwm.schedule.elites" getOrElse 10
+
+    new ScheduleServiceImpl(pops, gens, elites)
+  }
+}

--- a/app/services/ActorScheduler.scala
+++ b/app/services/ActorScheduler.scala
@@ -3,13 +3,14 @@ package services
 import java.time.LocalTime
 
 import akka.actor.{ActorRef, ActorSystem}
+import di.BackupServiceActorAnnotation
 import javax.inject.{Inject, Named}
 
 import scala.util.Try
 
 class ActorScheduler @Inject()(
   system: ActorSystem,
-  @Named("backupActor") ref1: ActorRef,
+  @BackupServiceActorAnnotation ref1: ActorRef,
   @Named("backupMessage") message1: Any,
   @Named("backupFireTime") fireTime1: String
 ) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -56,7 +56,8 @@ database {
     databaseName = ""
     password = ""
   }
-  numThreads = 10
-  connectionTimeout = 5000
-  keepAliveConnection = true
+  numThreads = 20 // The number of concurrent threads in the thread pool for asynchronous execution of database actions
+  queueSize = 1000 // The size of the queue for database actions which cannot be executed immediately when all threads are busy
+  connectionTimeout = 5000 // The maximum time (ms) to wait before a call to getConnection is timed out
+  // keepAliveConnection = true // If this is set to true, one extra connection will be opened as soon as the database is accessed for the first time, and kept open until close() is called. This is useful for named in-memory databases in test environments.
 }

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,10 +3,10 @@
 APP_CONF="conf/application.conf"
 KEYCLOAK_CONF="conf/keycloak.json"
 
-if git diff --cached --name-only | grep --quiet "$APP_CONF"
-then
-  git reset head $APP_CONF; git checkout -- $APP_CONF
-fi
+#if git diff --cached --name-only | grep --quiet "$APP_CONF"
+#then
+#  git reset head $APP_CONF; git checkout -- $APP_CONF
+#fi
 
 if git diff --cached --name-only | grep --quiet "$KEYCLOAK_CONF"
 then

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,10 +3,10 @@
 APP_CONF="conf/application.conf"
 KEYCLOAK_CONF="conf/keycloak.json"
 
-#if git diff --cached --name-only | grep --quiet "$APP_CONF"
-#then
-#  git reset head $APP_CONF; git checkout -- $APP_CONF
-#fi
+if git diff --cached --name-only | grep --quiet "$APP_CONF"
+then
+  git reset head $APP_CONF; git checkout -- $APP_CONF
+fi
 
 if git diff --cached --name-only | grep --quiet "$KEYCLOAK_CONF"
 then

--- a/test/base/PostgresDbSpec.scala
+++ b/test/base/PostgresDbSpec.scala
@@ -4,15 +4,16 @@ import database._
 import org.scalatest._
 import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import slick.jdbc.PostgresProfile
+import slick.jdbc.JdbcProfile
+import slick.jdbc.JdbcBackend.Database
 
 import scala.concurrent.Future
 
 abstract class PostgresDbSpec extends WordSpec with TestBaseDefinition with GuiceOneAppPerSuite with LwmFakeApplication {
+  val db = app.injector.instanceOf(classOf[Database])
 
-  import slick.jdbc.PostgresProfile.api._
-
-  val db = app.injector.instanceOf(classOf[PostgresProfile.backend.Database])
+  val profile: JdbcProfile = _root_.slick.jdbc.PostgresProfile
+  import profile.api._
 
   protected final def async[R](future: Future[R])(assert: R => Unit): Unit = whenReady(future, timeout(Span(5, Seconds)))(assert)
 

--- a/test/dao/ScheduleEntryDaoSpec.scala
+++ b/test/dao/ScheduleEntryDaoSpec.scala
@@ -118,8 +118,8 @@ final class ScheduleEntryDaoSpec extends AbstractExpandableDaoSpec[ScheduleEntry
 
   override protected val toAdd: List[ScheduleEntryDb] = {
     for {
-      labwork <- labworks drop 5
-      group <- groups drop 6
+      labwork <- labworks.slice(5, 9)
+      group <- groups.slice(6, 11)
     } yield {
       import scala.util.Random.nextInt
 


### PR DESCRIPTION
slick is now more integrated into the play framework (#93). however, we still don't use `play-slick`. it is more an isolated integration as suggested [here](https://github.com/playframework/play-scala-isolated-slick-ex…)