### PR TITLE
improved dashboard resource

### DIFF
--- a/app/auth/KeycloakAuthorization.scala
+++ b/app/auth/KeycloakAuthorization.scala
@@ -35,7 +35,7 @@ class KeycloakAuthorization @Inject()(keycloakDeployment: KeycloakDeployment, ws
   import KeycloakAuthorization._
 
   override def authorized[R](request: Request[R]): Future[VerifiedToken] = for {
-    token <- asFuture(bearerToken(request), s"could not find $BearerPrefix in $AuthorizationHeader header")
+    token <- asFuture(bearerToken(request), s"could not find $BearerPrefix Token in $AuthorizationHeader header")
     tokenVerifier = buildTokenVerifier(token)
     key <- getPublicKey(tokenVerifier.getHeader)
     accessToken = tokenVerifier.publicKey(key).verify().getToken

--- a/app/auth/OAuthAuthorization.scala
+++ b/app/auth/OAuthAuthorization.scala
@@ -10,12 +10,14 @@ trait OAuthAuthorization {
   def authorized[R](request: Request[R]): Future[VerifiedToken]
 
   def bearerToken[_](request: Request[_]): Option[String] = request.headers.get(AuthorizationHeader)
-    .filter(_.contains(BearerPrefix))
-    .map(_.stripPrefix(BearerPrefix))
+    .map(_.split(" "))
+    .filter(_.length == 2)
+    .filter(_.head.equalsIgnoreCase(BearerPrefix))
+    .map(_.last)
     .filter(_.nonEmpty)
 }
 
 object OAuthAuthorization {
   val AuthorizationHeader = "Authorization"
-  val BearerPrefix = "Bearer "
+  val BearerPrefix = "Bearer"
 }

--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -17,6 +17,7 @@ object DashboardController {
   lazy val systemIdAttribute = "systemId"
   lazy val numberOfUpcomingElementsAttribute = "numberOfUpcomingElements"
   lazy val entriesSinceNowAttribute = "entriesSinceNow"
+  lazy val sortedByDateAttribute = "sortedByDate"
 }
 
 @Singleton
@@ -48,7 +49,8 @@ final class DashboardController @Inject()(
       atomic = extractAttributes(request.queryString)._2.atomic
       numberOfUpcomingElements = intOf(request.queryString)(numberOfUpcomingElementsAttribute)
       entriesSinceNow = boolOf(request.queryString)(entriesSinceNowAttribute) getOrElse true
-      board <- dashboardDao.dashboard(id)(atomic, numberOfUpcomingElements, entriesSinceNow)
+      sortedByDate = boolOf(request.queryString)(sortedByDateAttribute) getOrElse true
+      board <- dashboardDao.dashboard(id)(atomic, numberOfUpcomingElements, entriesSinceNow, sortedByDate)
     } yield board).jsonResult(d => Ok(Json.toJson(d)))
   }
 

--- a/app/controllers/helper/ResultOps.scala
+++ b/app/controllers/helper/ResultOps.scala
@@ -11,9 +11,13 @@ trait ResultOps {
 
   protected def preconditionFailed(message: String): Result = PreconditionFailed(Json.obj("status" -> "KO", "message" -> message))
 
-  protected def internalServerError(throwable: Throwable): Result = internalServerError(throwable.getMessage)
-
-  protected def internalServerError(message: String): Result = InternalServerError(Json.obj("status" -> "KO", "message" -> message))
+  protected def internalServerError(throwable: Throwable): Result = InternalServerError(
+    Json.obj(
+      "status" -> "KO",
+      "message" -> throwable.getLocalizedMessage,
+      "stackTrace" -> throwable.getStackTrace.map(_.toString)
+    )
+  )
 
   protected def ok[A](entity: A)(implicit writes: Writes[A]): Result = Ok(Json.toJson(entity))
 

--- a/app/dao/AssignmentPlanDao.scala
+++ b/app/dao/AssignmentPlanDao.scala
@@ -27,7 +27,7 @@ trait AssignmentPlanDao extends AbstractDao[AssignmentPlanTable, AssignmentPlanD
   val assignmentEntryQuery: TableQuery[AssignmentEntryTable] = TableQuery[AssignmentEntryTable]
   val assignmentEntryTypeQuery: TableQuery[AssignmentEntryTypeTable] = TableQuery[AssignmentEntryTypeTable]
 
-  override protected def toAtomic(query: Query[AssignmentPlanTable, AssignmentPlanDb, Seq]): Future[Traversable[AssignmentPlanLike]] = collectDependencies(query) {
+  override protected def toAtomic(query: Query[AssignmentPlanTable, AssignmentPlanDb, Seq]): Future[Seq[AssignmentPlanLike]] = collectDependencies(query) {
     case (plan, labwork, entries) => AssignmentPlanAtom(labwork.toUniqueEntity, plan.attendance, plan.mandatory, entries, plan.id)
   }
 
@@ -59,12 +59,12 @@ trait AssignmentPlanDao extends AbstractDao[AssignmentPlanTable, AssignmentPlanD
         val entries = assignmentEntries(dependencies.map(_._2))
 
         build(assignmentPlan, labwork, entries)
-    })
+    }.toSeq)
 
     db.run(action)
   }
 
-  override protected def toUniqueEntity(query: Query[AssignmentPlanTable, AssignmentPlanDb, Seq]): Future[Traversable[AssignmentPlanLike]] = collectDependencies(query) {
+  override protected def toUniqueEntity(query: Query[AssignmentPlanTable, AssignmentPlanDb, Seq]): Future[Seq[AssignmentPlanLike]] = collectDependencies(query) {
     case (plan, labwork, entries) => AssignmentPlan(labwork.id, plan.attendance, plan.mandatory, entries, plan.id)
   }
 

--- a/app/dao/BlacklistDao.scala
+++ b/app/dao/BlacklistDao.scala
@@ -3,7 +3,6 @@ package dao
 import database.{BlacklistDb, BlacklistTable, TableFilter}
 import javax.inject.Inject
 import models.Blacklist
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import utils.LwmDateTime._
 
@@ -41,9 +40,9 @@ trait BlacklistDao extends AbstractDao[BlacklistTable, BlacklistDb, Blacklist] {
 
   override val tableQuery = TableQuery[BlacklistTable]
 
-  override protected def toAtomic(query: Query[BlacklistTable, BlacklistDb, Seq]): Future[Traversable[Blacklist]] = toUniqueEntity(query)
+  override protected def toAtomic(query: Query[BlacklistTable, BlacklistDb, Seq]): Future[Seq[Blacklist]] = toUniqueEntity(query)
 
-  override protected def toUniqueEntity(query: Query[BlacklistTable, BlacklistDb, Seq]): Future[Traversable[Blacklist]] = {
+  override protected def toUniqueEntity(query: Query[BlacklistTable, BlacklistDb, Seq]): Future[Seq[Blacklist]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 

--- a/app/dao/CourseDao.scala
+++ b/app/dao/CourseDao.scala
@@ -3,7 +3,6 @@ package dao
 import database.{CourseDb, CourseTable, TableFilter}
 import javax.inject.Inject
 import models.{CourseAtom, CourseLike}
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -35,7 +34,7 @@ trait CourseDao extends AbstractDao[CourseTable, CourseDb, CourseLike] {
       (existing.semesterIndex == toUpdate.semesterIndex && existing.label == toUpdate.label)
   }
 
-  override protected def toAtomic(query: Query[CourseTable, CourseDb, Seq]): Future[Traversable[CourseLike]] = {
+  override protected def toAtomic(query: Query[CourseTable, CourseDb, Seq]): Future[Seq[CourseLike]] = {
     val joinedQuery = for {
       q <- query
       l <- q.lecturerFk
@@ -46,7 +45,7 @@ trait CourseDao extends AbstractDao[CourseTable, CourseDb, CourseLike] {
     }))
   }
 
-  override protected def toUniqueEntity(query: Query[CourseTable, CourseDb, Seq]): Future[Traversable[CourseLike]] = {
+  override protected def toUniqueEntity(query: Query[CourseTable, CourseDb, Seq]): Future[Seq[CourseLike]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 }

--- a/app/dao/DashboardDao.scala
+++ b/app/dao/DashboardDao.scala
@@ -5,22 +5,22 @@ import java.util.UUID
 import dao.helper.Core
 import database.helper.{EmployeeStatus, StudentStatus}
 import javax.inject.Inject
-import models.{AuthorityAtom, Dashboard, EmployeeDashboard, Semester, Student, StudentDashboard, User}
+import models.{AuthorityAtom, Dashboard, EmployeeDashboard, ReportCardEntryType, ReportCardEvaluationAtom, Semester, StudentDashboard, StudentLike, User}
 import org.joda.time.LocalDate
 import slick.jdbc.PostgresProfile.api._
 import utils.LwmDateTime._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait DashboardDao extends Core { // TODO continue
+trait DashboardDao extends Core {
 
   def dashboard(systemId: String)(atomic: Boolean, numberOfUpcomingElements: Option[Int], entriesSinceNow: Boolean, sortedByDate: Boolean): Future[Dashboard] = {
     for {
-      maybeSemester <- semesterDao.getSingle(UUID.fromString("0496eec7-ad06-4d82-86e1-ad7782dcd92b")) //semesterDao.current(atomic)
-      semester <- maybeSemester.fold(throw new Throwable(s"none or more than one semester was found, which is marked as the current semester"))(Future.successful)
-      user <- userDao.getSingleWhere(_.systemId === systemId, atomic = false)
+      maybeSemester <- semesterDao.getSingle(UUID.fromString("0496eec7-ad06-4d82-86e1-ad7782dcd92b")) // semesterDao.current(atomic)
+      semester <- maybeSemester.fold(throw new Throwable(s"none or more than one semester was found, but there should only one current semester"))(Future.successful)
+      user <- userDao.getSingleWhere(_.systemId === systemId, atomic = atomic)
       board <- user match {
-        case Some(student: Student) =>
+        case Some(student: StudentLike) =>
           studentDashboard(student, semester)(atomic, numberOfUpcomingElements, entriesSinceNow, sortedByDate)
         case Some(employee) =>
           employeeDashboard(employee, semester)(atomic, numberOfUpcomingElements, entriesSinceNow, sortedByDate)
@@ -30,33 +30,53 @@ trait DashboardDao extends Core { // TODO continue
     } yield board
   }
 
-  private def studentDashboard(student: Student, semester: Semester)(atomic: Boolean, numberOfUpcomingElements: Option[Int], entriesSinceNow: Boolean, sortedByDate: Boolean) = { // current semester
-    //    for {
-    //      labworks <- labworkDao.filter(l => l.semester === semester.id && l.degree === enrollment, atomic, validOnly, sinceLastModified)
-    //      labworIds = labworks.map(_.id)
-    //
-    //      apps <- labworkApplicationDao.filter(app => app.applicant === student && app.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified) // split into passed/not passed & filter not published
-    //      groups <- groupDao.filter(g => g.contains(student) && g.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
-    //      cards <- reportCardEntryDao.filter(e => e.student === student && e.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified) // labwork is published & take first n upcoming elements
-    //      evals <- reportCardEvaluationDao.filter(_.student === student, atomic, validOnly, sinceLastModified) // with semester and combine with patterns
-    //      evalPatterns <- reportCardEvaluationPatternDao.filter(_.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
-    //    } yield StudentDashboard(semester, labworks, apps, groups, cards, evals, evalPatterns)
-    Future.successful(StudentDashboard(student, StudentStatus, semester, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty))
+  private def studentDashboard(student: StudentLike, semester: Semester)(atomic: Boolean, numberOfUpcomingElements: Option[Int], entriesSinceNow: Boolean, sortedByDate: Boolean) = {
+    for {
+      labworks <- labworkDao get(List(LabworkSemesterFilter(semester.id.toString), LabworkDegreeFilter(student.enrollmentId.toString)), atomic = atomic)
+      labworkIds = labworks map (_.id)
+
+      lappQuery = labworkApplicationDao filterValidOnly (app => app.labwork.inSet(labworkIds) && app.applicant === student.id)
+      lapps <- labworkApplicationDao getByQuery(lappQuery, atomic = atomic)
+
+      allCardsQuery = reportCardEntryDao filterValidOnly (e => e.labwork.inSet(labworkIds) && e.student === student.id)
+      sinceNowFilter = if (entriesSinceNow) Option apply ReportCardEntrySinceFilter(LocalDate.now.stringMillis).predicate else Option.empty
+      cardsSinceNowQuery = sinceNowFilter.fold(allCardsQuery)(f => allCardsQuery.filter(f.apply))
+      cards <- reportCardEntryDao getByQuery(cardsSinceNowQuery, atomic = atomic)
+      upcomingCards = numberOfUpcomingElements.fold(cards)(n => cards.groupBy(_.labworkId).flatMap(_._2.take(n)).toSeq)
+      sortedUpcomingCards = if (sortedByDate) upcomingCards sortBy (s => (s.date, s.start)) else upcomingCards
+
+      allEvals <- reportCardEvaluationDao get(List(StudentFilter(student.id.toString)), atomic = true) // must be atomic
+      passedEvals = allEvals map (_.asInstanceOf[ReportCardEvaluationAtom]) groupBy (_.labwork) map {
+        case (labwork, evals) =>
+          val boolBased = evals filter (e => ReportCardEntryType.BooleanBasedTypes.exists(_.entryType == e.label))
+          val intBased = evals filter (e => ReportCardEntryType.IntBasedTypes.exists(_.entryType == e.label))
+
+          val passed = boolBased map (_.bool) reduceOption (_ && _) getOrElse false
+          val bonus = intBased map (_.int) sum
+
+          (labwork.course.abbreviation, labwork.semester.abbreviation, passed, bonus)
+      }
+
+      groupsQuery = groupDao filterValidOnly (g => g.labwork.inSet(labworkIds) && g.contains(student.id)) map (g => (g.label, g.labwork))
+      groupLabels <- db run groupsQuery.result
+      groups = groupLabels.map(g => (g._1, labworks.find(_.id == g._2).get))
+
+    } yield StudentDashboard(student, StudentStatus, semester, labworks, lapps, groups, sortedUpcomingCards, allEvals, passedEvals toSeq)
   }
 
   private def employeeDashboard(employee: User, semester: Semester)(atomic: Boolean, numberOfUpcomingElements: Option[Int], entriesSinceNow: Boolean, sortedByDate: Boolean) = {
     for {
-      authorities <- authorityDao.get(List(AuthorityUserFilter(employee.id.toString))) // must be atomic
-      courses = authorities.flatMap(_.asInstanceOf[AuthorityAtom].course)
-      courseIds = courses.map(_.id)
+      authorities <- authorityDao get List(AuthorityUserFilter(employee.id.toString)) // must be atomic ...
+      courses = authorities flatMap (_.asInstanceOf[AuthorityAtom].course) // in order to get his/her courses
+      courseIds = courses map (_.id)
 
-      inSemesterAndCourse = scheduleEntryDao.filterValidOnly(q => q.labworkFk.filter(_.semester === semester.id).exists && q.memberOfCourses(courseIds))
-      sinceNowFilter = if (entriesSinceNow) Option.apply(ScheduleEntrySinceFilter(LocalDate.now.stringMillis).predicate) else Option.empty
+      inSemesterAndCourse = scheduleEntryDao filterValidOnly (q => q.labworkFk.filter(_.semester === semester.id).exists && q.memberOfCourses(courseIds))
+      sinceNowFilter = if (entriesSinceNow) Option apply ScheduleEntrySinceFilter(LocalDate.now.stringMillis).predicate else Option.empty
       isSemesterAndCourseAndSinceNow = sinceNowFilter.fold(inSemesterAndCourse)(f => inSemesterAndCourse.filter(f.apply))
 
-      scheduleEntries <- scheduleEntryDao.getByQuery(isSemesterAndCourseAndSinceNow, atomic = atomic)
+      scheduleEntries <- scheduleEntryDao getByQuery(isSemesterAndCourseAndSinceNow, atomic = atomic)
       upcomingEntries = numberOfUpcomingElements.fold(scheduleEntries)(n => scheduleEntries.groupBy(_.labworkId).flatMap(_._2.take(n)).toSeq)
-      sortedUpcomingEntries = if (sortedByDate) upcomingEntries.sortBy(s => (s.date, s.start)) else upcomingEntries
+      sortedUpcomingEntries = if (sortedByDate) upcomingEntries sortBy (s => (s.date, s.start)) else upcomingEntries
 
     } yield EmployeeDashboard(employee, EmployeeStatus, semester, courses, sortedUpcomingEntries)
   }
@@ -73,8 +93,6 @@ trait DashboardDao extends Core { // TODO continue
 
   protected def reportCardEvaluationDao: ReportCardEvaluationDao
 
-  protected def reportCardEvaluationPatternDao: ReportCardEvaluationPatternDao
-
   protected def groupDao: GroupDao
 
   protected def authorityDao: AuthorityDao
@@ -90,7 +108,6 @@ final class DashboardDaoImpl @Inject()(
   val labworkApplicationDao: LabworkApplicationDao,
   val reportCardEntryDao: ReportCardEntryDao,
   val reportCardEvaluationDao: ReportCardEvaluationDao,
-  val reportCardEvaluationPatternDao: ReportCardEvaluationPatternDao,
   val groupDao: GroupDao,
   val authorityDao: AuthorityDao,
   val scheduleEntryDao: ScheduleEntryDao,

--- a/app/dao/DashboardDao.scala
+++ b/app/dao/DashboardDao.scala
@@ -10,39 +10,47 @@ import utils.LwmDateTime._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait DashboardDao extends Core { // TODO check and refactor
+trait DashboardDao extends Core { // TODO continue
 
-  def dashboard(systemId: String)(atomic: Boolean, validOnly: Boolean, sinceLastModified: Option[String]) = {
-    semesterDao.get(List(SemesterCurrentFilter), atomic, validOnly, sinceLastModified) map (_.toList) flatMap {
-      case head :: Nil =>
-        userDao.get(List(UserSystemIdFilter(systemId)), atomic = false, validOnly, sinceLastModified).map(_.headOption) flatMap {
-          case Some(Student(_, _, _, _, _, enrollment, id)) => student(id, enrollment, head)(atomic, validOnly, sinceLastModified)
-          case Some(user) => employee(user.id, head)(atomic, validOnly, sinceLastModified)
-          case None => Future.failed(new Throwable(s"no user found for $systemId"))
-        }
-      case _ =>
-        Future.failed(new Throwable(s"none or more than one semester was found, which is marked as the current semester"))
-    }
+  def dashboard(systemId: String)(atomic: Boolean) = {
+    for {
+      maybeSemester <- semesterDao.current(atomic)
+      semester <- maybeSemester.fold(throw new Throwable(s"none or more than one semester was found, which is marked as the current semester"))(Future.successful)
+      user <- userDao.getSingleWhere(_.systemId === systemId, atomic = false)
+      board <- user match {
+        case Some(Student(_, _, _, _, _, enrollment, id)) =>
+          studentDashboard(id, enrollment, semester)(atomic)
+        case Some(employee) =>
+          employeeDashboard(employee.id, semester)(atomic)
+        case None =>
+          throw new Throwable(s"no user found for $systemId")
+      }
+    } yield board
   }
 
-  private def student(student: UUID, enrollment: UUID, semester: Semester)(atomic: Boolean, validOnly: Boolean, sinceLastModified: Option[String]) = for {
-    labworks <- labworkDao.filter(l => l.semester === semester.id && l.degree === enrollment, atomic, validOnly, sinceLastModified)
-    labworIds = labworks.map(_.id)
+  private def studentDashboard(student: UUID, enrollment: UUID, semester: Semester)(atomic: Boolean) = {
+//    for {
+//      labworks <- labworkDao.filter(l => l.semester === semester.id && l.degree === enrollment, atomic, validOnly, sinceLastModified)
+//      labworIds = labworks.map(_.id)
+//
+//      apps <- labworkApplicationDao.filter(app => app.applicant === student && app.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
+//      groups <- groupDao.filter(g => g.contains(student) && g.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
+//      cards <- reportCardEntryDao.filter(e => e.student === student && e.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
+//      evals <- reportCardEvaluationDao.filter(_.student === student, atomic, validOnly, sinceLastModified)
+//      evalPatterns <- reportCardEvaluationPatternDao.filter(_.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
+//    } yield StudentDashboard(semester, labworks, apps, groups, cards, evals, evalPatterns)
+    Future.successful(???)
+  }
 
-    apps <- labworkApplicationDao.filter(app => app.applicant === student && app.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
-    groups <- groupDao.filter(g => g.contains(student) && g.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
-    cards <- reportCardEntryDao.filter(e => e.student === student && e.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
-    evals <- reportCardEvaluationDao.filter(_.student === student, atomic, validOnly, sinceLastModified)
-    evalPatterns <- reportCardEvaluationPatternDao.filter(_.labwork.inSet(labworIds), atomic, validOnly, sinceLastModified)
-  } yield StudentDashboard(semester, labworks, apps, groups, cards, evals, evalPatterns)
+  private def employeeDashboard(employee: UUID, semester: Semester)(atomic: Boolean) = {
+    for {
+      auths <- authorityDao.get(List(AuthorityUserFilter(employee.toString))) // must be atomic
+      courses = auths.flatMap(_.asInstanceOf[AuthorityAtom].course)
 
-  private def employee(employee: UUID, semester: Semester)(atomic: Boolean, validOnly: Boolean, sinceLastModified: Option[String]) = for {
-    auths <- authorityDao.get(List(AuthorityUserFilter(employee.toString)), atomic = true, validOnly, sinceLastModified) // must be atomic
-    courses = auths.filter(_.isInstanceOf[AuthorityAtom]).map(_.asInstanceOf[AuthorityAtom]).flatMap(_.course)
-
-    scheduleEntryFilter = List(ScheduleEntrySupervisorFilter(employee.toString), ScheduleEntrySinceFilter(semester.start.stringMillis), ScheduleEntryUntilFilter(semester.end.stringMillis))
-    scheduleEntries <- scheduleEntryDao.get(scheduleEntryFilter, atomic, validOnly, sinceLastModified)
-  } yield EmployeeDashboard(semester, courses, scheduleEntries)
+      scheduleEntryFilter = List(ScheduleEntrySupervisorFilter(employee.toString), ScheduleEntrySinceFilter(semester.start.stringMillis), ScheduleEntryUntilFilter(semester.end.stringMillis))
+      scheduleEntries <- scheduleEntryDao.get(scheduleEntryFilter, atomic)
+    } yield EmployeeDashboard(semester, courses, scheduleEntries)
+  }
 
   protected def userDao: UserDao
 

--- a/app/dao/DashboardDao.scala
+++ b/app/dao/DashboardDao.scala
@@ -51,8 +51,8 @@ trait DashboardDao extends Core { // TODO continue
       courseIds = courses.map(_.id)
 
       now = ScheduleEntrySinceFilter(LocalDate.now.stringMillis).predicate
-      currentEntries = scheduleEntryDao.tableQuery
-        .filter(q => q.labworkFk.filter(_.semester === semester.id).exists && q.memberOfCourses(courseIds) && now.apply(q))
+      currentEntries = scheduleEntryDao
+        .filterValidOnly(q => q.labworkFk.filter(_.semester === semester.id).exists && q.memberOfCourses(courseIds) && now.apply(q))
         .sortBy(q => (q.date.asc, q.start.asc))
 
       scheduleEntries <- scheduleEntryDao.getByQuery(currentEntries, atomic = atomic)

--- a/app/dao/DegreeDao.scala
+++ b/app/dao/DegreeDao.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import database.{DegreeDb, DegreeTable, TableFilter}
 import javax.inject.Inject
 import models.Degree
-import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,9 +33,9 @@ trait DegreeDao extends AbstractDao[DegreeTable, DegreeDb, Degree] {
     filterBy(List(DegreeAbbreviationFilter(entity.abbreviation)))
   }
 
-  override protected def toAtomic(query: Query[DegreeTable, DegreeDb, Seq]): Future[Traversable[Degree]] = toUniqueEntity(query)
+  override protected def toAtomic(query: Query[DegreeTable, DegreeDb, Seq]): Future[Seq[Degree]] = toUniqueEntity(query)
 
-  override protected def toUniqueEntity(query: Query[DegreeTable, DegreeDb, Seq]): Future[Traversable[Degree]] = db.run(query.result.map(_.map(_.toUniqueEntity)))
+  override protected def toUniqueEntity(query: Query[DegreeTable, DegreeDb, Seq]): Future[Seq[Degree]] = db.run(query.result.map(_.map(_.toUniqueEntity)))
 }
 
 final class DegreeDaoImpl @Inject()(val db: Database, val executionContext: ExecutionContext) extends DegreeDao

--- a/app/dao/GroupDao.scala
+++ b/app/dao/GroupDao.scala
@@ -30,11 +30,11 @@ trait GroupDao extends AbstractDao[GroupTable, GroupDb, GroupLike] {
 
   val groupMembershipQuery: TableQuery[GroupMembershipTable] = TableQuery[GroupMembershipTable]
 
-  override protected def toAtomic(query: Query[GroupTable, GroupDb, Seq]): Future[Traversable[GroupLike]] = collectDependencies(query) {
+  override protected def toAtomic(query: Query[GroupTable, GroupDb, Seq]): Future[Seq[GroupLike]] = collectDependencies(query) {
     case (g, l, m) => GroupAtom(g.label, l.toUniqueEntity, m.map(_.toUniqueEntity).toSet, g.id)
   }
 
-  override protected def toUniqueEntity(query: Query[GroupTable, GroupDb, Seq]): Future[Traversable[GroupLike]] = collectDependencies(query) {
+  override protected def toUniqueEntity(query: Query[GroupTable, GroupDb, Seq]): Future[Seq[GroupLike]] = collectDependencies(query) {
     case (g, _, m) => Group(g.label, g.labwork, m.map(_.id).toSet, g.id)
   }
 
@@ -54,7 +54,7 @@ trait GroupDao extends AbstractDao[GroupTable, GroupDb, GroupLike] {
         val labwork = dependencies.find(_._1._1._1.labwork == group.labwork).head._1._1._2
 
         build(group, labwork, members)
-    }))
+    }.toSeq))
   }
 
   override protected def existsQuery(entity: GroupDb): Query[GroupTable, GroupDb, Seq] = {

--- a/app/dao/LabworkApplicationDao.scala
+++ b/app/dao/LabworkApplicationDao.scala
@@ -60,7 +60,7 @@ trait LabworkApplicationDao extends AbstractDao[LabworkApplicationTable, Labwork
     ))
   }
 
-  override protected def toAtomic(query: Query[LabworkApplicationTable, LabworkApplicationDb, Seq]): Future[Traversable[LabworkApplicationLike]] = joinDependencies(query) {
+  override protected def toAtomic(query: Query[LabworkApplicationTable, LabworkApplicationDb, Seq]): Future[Seq[LabworkApplicationLike]] = joinDependencies(query) {
     case (labworkApplication, dependencies) =>
       val ((lapp, lab, applicant, (course, degree, semester, lecturer)), _) = dependencies.find(_._1._1.id == labworkApplication.id).get
       val friends = dependencies.flatMap(_._2.map(_.toUniqueEntity))
@@ -72,7 +72,7 @@ trait LabworkApplicationDao extends AbstractDao[LabworkApplicationTable, Labwork
       LabworkApplicationAtom(labworkAtom, applicant.toUniqueEntity, friends.toSet, lapp.lastModified.dateTime, lapp.id)
   }
 
-  override protected def toUniqueEntity(query: Query[LabworkApplicationTable, LabworkApplicationDb, Seq]): Future[Traversable[LabworkApplicationLike]] = joinDependencies(query) {
+  override protected def toUniqueEntity(query: Query[LabworkApplicationTable, LabworkApplicationDb, Seq]): Future[Seq[LabworkApplicationLike]] = joinDependencies(query) {
     case (lapp, dependencies) =>
       val friends = dependencies.flatMap(_._2.map(_.id))
       LabworkApplication(lapp.labwork, lapp.applicant, friends.toSet, lapp.lastModified.dateTime, lapp.id)
@@ -96,7 +96,7 @@ trait LabworkApplicationDao extends AbstractDao[LabworkApplicationTable, Labwork
       case (((lapp, lab, a, (c, d, s, lec)), _), friend) => ((lapp, lab, a, (c, d, s, lec)), friend)
     }.result.map(_.groupBy(_._1._1).map {
       case (labworkApplication, dependencies) => build(labworkApplication, dependencies)
-    }))
+    }.toSeq))
   }
 
   override protected val databaseExpander: Option[DatabaseExpander[LabworkApplicationDb]] = Some(new DatabaseExpander[LabworkApplicationDb] {

--- a/app/dao/LabworkDao.scala
+++ b/app/dao/LabworkDao.scala
@@ -57,7 +57,7 @@ trait LabworkDao extends AbstractDao[LabworkTable, LabworkDb, LabworkLike] {
     ))
   }
 
-  override protected def toAtomic(query: Query[LabworkTable, LabworkDb, Seq]): Future[Traversable[LabworkLike]] = {
+  override protected def toAtomic(query: Query[LabworkTable, LabworkDb, Seq]): Future[Seq[LabworkLike]] = {
     val joinedQuery = for {
       q <- query
       c <- q.courseFk
@@ -73,7 +73,7 @@ trait LabworkDao extends AbstractDao[LabworkTable, LabworkDb, LabworkLike] {
     }))
   }
 
-  override protected def toUniqueEntity(query: Query[LabworkTable, LabworkDb, Seq]): Future[Traversable[LabworkLike]] = {
+  override protected def toUniqueEntity(query: Query[LabworkTable, LabworkDb, Seq]): Future[Seq[LabworkLike]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 }

--- a/app/dao/ReportCardEntryTypeDao.scala
+++ b/app/dao/ReportCardEntryTypeDao.scala
@@ -29,9 +29,9 @@ trait ReportCardEntryTypeDao extends AbstractDao[ReportCardEntryTypeTable, Repor
 
   override val tableQuery = TableQuery[ReportCardEntryTypeTable]
 
-  override protected def toAtomic(query: Query[ReportCardEntryTypeTable, ReportCardEntryTypeDb, Seq]): Future[Traversable[ReportCardEntryType]] = toUniqueEntity(query)
+  override protected def toAtomic(query: Query[ReportCardEntryTypeTable, ReportCardEntryTypeDb, Seq]): Future[Seq[ReportCardEntryType]] = toUniqueEntity(query)
 
-  override protected def toUniqueEntity(query: Query[ReportCardEntryTypeTable, ReportCardEntryTypeDb, Seq]): Future[Traversable[ReportCardEntryType]] = {
+  override protected def toUniqueEntity(query: Query[ReportCardEntryTypeTable, ReportCardEntryTypeDb, Seq]): Future[Seq[ReportCardEntryType]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 

--- a/app/dao/ReportCardEvaluationDao.scala
+++ b/app/dao/ReportCardEvaluationDao.scala
@@ -48,7 +48,7 @@ trait ReportCardEvaluationDao extends AbstractDao[ReportCardEvaluationTable, Rep
 
   override val tableQuery = TableQuery[ReportCardEvaluationTable]
 
-  override protected def toAtomic(query: Query[ReportCardEvaluationTable, ReportCardEvaluationDb, Seq]): Future[Traversable[ReportCardEvaluationLike]] = {
+  override protected def toAtomic(query: Query[ReportCardEvaluationTable, ReportCardEvaluationDb, Seq]): Future[Seq[ReportCardEvaluationLike]] = {
     val mandatory = for {
       q <- query
       labwork <- q.labworkFk
@@ -70,7 +70,7 @@ trait ReportCardEvaluationDao extends AbstractDao[ReportCardEvaluationTable, Rep
     }))
   }
 
-  override protected def toUniqueEntity(query: Query[ReportCardEvaluationTable, ReportCardEvaluationDb, Seq]): Future[Traversable[ReportCardEvaluationLike]] = {
+  override protected def toUniqueEntity(query: Query[ReportCardEvaluationTable, ReportCardEvaluationDb, Seq]): Future[Seq[ReportCardEvaluationLike]] = {
     db.run(query.result.map(_.map(e => ReportCardEvaluation(e.student, e.labwork, e.label, e.bool, e.int, e.lastModified.dateTime, e.id))))
   }
 

--- a/app/dao/ReportCardEvaluationPatternDao.scala
+++ b/app/dao/ReportCardEvaluationPatternDao.scala
@@ -30,9 +30,9 @@ trait ReportCardEvaluationPatternDao extends AbstractDao[ReportCardEvaluationPat
 
   override val tableQuery = TableQuery[ReportCardEvaluationPatternTable]
 
-  override protected def toAtomic(query: Query[ReportCardEvaluationPatternTable, ReportCardEvaluationPatternDb, Seq]): Future[Traversable[ReportCardEvaluationPattern]] = toUniqueEntity(query)
+  override protected def toAtomic(query: Query[ReportCardEvaluationPatternTable, ReportCardEvaluationPatternDb, Seq]): Future[Seq[ReportCardEvaluationPattern]] = toUniqueEntity(query)
 
-  override protected def toUniqueEntity(query: Query[ReportCardEvaluationPatternTable, ReportCardEvaluationPatternDb, Seq]): Future[Traversable[ReportCardEvaluationPattern]] = {
+  override protected def toUniqueEntity(query: Query[ReportCardEvaluationPatternTable, ReportCardEvaluationPatternDb, Seq]): Future[Seq[ReportCardEvaluationPattern]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 

--- a/app/dao/ReportCardRescheduledDao.scala
+++ b/app/dao/ReportCardRescheduledDao.scala
@@ -27,7 +27,7 @@ trait ReportCardRescheduledDao extends AbstractDao[ReportCardRescheduledTable, R
 
   override val tableQuery = TableQuery[ReportCardRescheduledTable]
 
-  override protected def toAtomic(query: Query[ReportCardRescheduledTable, ReportCardRescheduledDb, Seq]): Future[Traversable[ReportCardRescheduledLike]] = {
+  override protected def toAtomic(query: Query[ReportCardRescheduledTable, ReportCardRescheduledDb, Seq]): Future[Seq[ReportCardRescheduledLike]] = {
     val mandatory = for {
       q <- query
       r <- q.roomFk
@@ -38,7 +38,7 @@ trait ReportCardRescheduledDao extends AbstractDao[ReportCardRescheduledTable, R
     }))
   }
 
-  override protected def toUniqueEntity(query: Query[ReportCardRescheduledTable, ReportCardRescheduledDb, Seq]): Future[Traversable[ReportCardRescheduledLike]] = {
+  override protected def toUniqueEntity(query: Query[ReportCardRescheduledTable, ReportCardRescheduledDb, Seq]): Future[Seq[ReportCardRescheduledLike]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 

--- a/app/dao/ReportCardRetryDao.scala
+++ b/app/dao/ReportCardRetryDao.scala
@@ -30,7 +30,7 @@ trait ReportCardRetryDao extends AbstractDao[ReportCardRetryTable, ReportCardRet
   override val tableQuery = TableQuery[ReportCardRetryTable]
   val entryTypeQuery: TableQuery[ReportCardEntryTypeTable] = TableQuery[ReportCardEntryTypeTable]
 
-  override protected def toAtomic(query: Query[ReportCardRetryTable, ReportCardRetryDb, Seq]): Future[Traversable[ReportCardRetryLike]] = collectDependencies(query) {
+  override protected def toAtomic(query: Query[ReportCardRetryTable, ReportCardRetryDb, Seq]): Future[Seq[ReportCardRetryLike]] = collectDependencies(query) {
     case (entry, room, entryTypes) => ReportCardRetryAtom(
       entry.date.localDate,
       entry.start.localTime,
@@ -42,7 +42,7 @@ trait ReportCardRetryDao extends AbstractDao[ReportCardRetryTable, ReportCardRet
     )
   }
 
-  override protected def toUniqueEntity(query: Query[ReportCardRetryTable, ReportCardRetryDb, Seq]): Future[Traversable[ReportCardRetryLike]] = collectDependencies(query) {
+  override protected def toUniqueEntity(query: Query[ReportCardRetryTable, ReportCardRetryDb, Seq]): Future[Seq[ReportCardRetryLike]] = collectDependencies(query) {
     case (entry, _, entryTypes) => entry.copy(entryTypes = entryTypes.toSet).toUniqueEntity
   }
 
@@ -59,7 +59,7 @@ trait ReportCardRetryDao extends AbstractDao[ReportCardRetryTable, ReportCardRet
       val entryTypes = dependencies.flatMap(_._2) // rhs
 
         build(retry, room, entryTypes)
-    })
+    }.toSeq)
 
     db.run(action)
   }

--- a/app/dao/RoleDao.scala
+++ b/app/dao/RoleDao.scala
@@ -26,9 +26,9 @@ trait RoleDao extends AbstractDao[RoleTable, RoleDb, Role] {
     filterBy(List(RoleLabelFilter(entity.label)))
   }
 
-  override protected def toAtomic(query: Query[RoleTable, RoleDb, Seq]): Future[Traversable[Role]] = toUniqueEntity(query)
+  override protected def toAtomic(query: Query[RoleTable, RoleDb, Seq]): Future[Seq[Role]] = toUniqueEntity(query)
 
-  override protected def toUniqueEntity(query: Query[RoleTable, RoleDb, Seq]): Future[Traversable[Role]] = {
+  override protected def toUniqueEntity(query: Query[RoleTable, RoleDb, Seq]): Future[Seq[Role]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 

--- a/app/dao/RoomDao.scala
+++ b/app/dao/RoomDao.scala
@@ -31,9 +31,9 @@ trait RoomDao extends AbstractDao[RoomTable, RoomDb, Room] {
       existing.label == toUpdate.label
   }
 
-  override protected def toAtomic(query: Query[RoomTable, RoomDb, Seq]): Future[Traversable[Room]] = toUniqueEntity(query)
+  override protected def toAtomic(query: Query[RoomTable, RoomDb, Seq]): Future[Seq[Room]] = toUniqueEntity(query)
 
-  override protected def toUniqueEntity(query: Query[RoomTable, RoomDb, Seq]): Future[Traversable[Room]] = {
+  override protected def toUniqueEntity(query: Query[RoomTable, RoomDb, Seq]): Future[Seq[Room]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 }

--- a/app/dao/SemesterDao.scala
+++ b/app/dao/SemesterDao.scala
@@ -50,6 +50,8 @@ trait SemesterDao extends AbstractDao[SemesterTable, SemesterDb, Semester] {
 
   override val tableQuery: TableQuery[SemesterTable] = TableQuery[SemesterTable]
 
+  final def current(atomic: Boolean) = getSingleWhere(SemesterCurrentFilter.predicate)
+
   override protected def shouldUpdate(existing: SemesterDb, toUpdate: SemesterDb): Boolean = {
     import utils.LwmDateTime.SqlDateConverter
 

--- a/app/dao/SemesterDao.scala
+++ b/app/dao/SemesterDao.scala
@@ -68,9 +68,9 @@ trait SemesterDao extends AbstractDao[SemesterTable, SemesterDb, Semester] {
     ))
   }
 
-  override protected def toAtomic(query: PostgresProfile.api.Query[SemesterTable, SemesterDb, Seq]): Future[Traversable[Semester]] = toUniqueEntity(query)
+  override protected def toAtomic(query: PostgresProfile.api.Query[SemesterTable, SemesterDb, Seq]): Future[Seq[Semester]] = toUniqueEntity(query)
 
-  override protected def toUniqueEntity(query: PostgresProfile.api.Query[SemesterTable, SemesterDb, Seq]): Future[Traversable[Semester]] = {
+  override protected def toUniqueEntity(query: PostgresProfile.api.Query[SemesterTable, SemesterDb, Seq]): Future[Seq[Semester]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 }

--- a/app/dao/UserDao.scala
+++ b/app/dao/UserDao.scala
@@ -154,11 +154,11 @@ trait UserDao extends AbstractDao[UserTable, UserDb, User] {
     filterBy(List(UserSystemIdFilter(entity.systemId)))
   }
 
-  override protected def toUniqueEntity(query: Query[UserTable, UserDb, Seq]): Future[Traversable[User]] = {
+  override protected def toUniqueEntity(query: Query[UserTable, UserDb, Seq]): Future[Seq[User]] = {
     db.run(query.result.map(_.map(_.toUniqueEntity)))
   }
 
-  override protected def toAtomic(query: Query[UserTable, UserDb, Seq]): Future[Traversable[User]] = {
+  override protected def toAtomic(query: Query[UserTable, UserDb, Seq]): Future[Seq[User]] = {
     db.run(query.joinLeft(degreeDao.tableQuery).on(_.enrollment === _.id).result.map(_.map {
       case (s, Some(d)) => StudentAtom(s.systemId, s.lastname, s.firstname, s.email, s.registrationId.head, d.toUniqueEntity, s.id)
       case (dbUser, None) => dbUser.toUniqueEntity

--- a/app/dao/helper/Retrieved.scala
+++ b/app/dao/helper/Retrieved.scala
@@ -8,15 +8,15 @@ import models.{UniqueDbEntity, UniqueEntity}
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.Rep
 
-import scala.collection.Traversable
+import scala.collection.Seq
 import scala.concurrent.Future
 
 trait Retrieved[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity, LwmModel <: UniqueEntity] {
   self: Core with Accessible[T, DbModel] =>
 
-  protected def toAtomic(query: Query[T, DbModel, Seq]): Future[Traversable[LwmModel]]
+  protected def toAtomic(query: Query[T, DbModel, Seq]): Future[Seq[LwmModel]]
 
-  protected def toUniqueEntity(query: Query[T, DbModel, Seq]): Future[Traversable[LwmModel]]
+  protected def toUniqueEntity(query: Query[T, DbModel, Seq]): Future[Seq[LwmModel]]
 
   final def filterBy(tableFilter: List[TableFilter[T]], validOnly: Boolean = true, sinceLastModified: Option[String] = None): Query[T, DbModel, Seq] = {
     val query = tableFilter match {
@@ -30,15 +30,15 @@ trait Retrieved[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity,
     query.filterBy(validOnly, sinceLastModified)
   }
 
-  final def get(tableFilter: List[TableFilter[T]] = List.empty, atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Traversable[LwmModel]] =
+  final def get(tableFilter: List[TableFilter[T]] = List.empty, atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Seq[LwmModel]] =
     filterBy(tableFilter, validOnly, sinceLastModified)
       .retrieve(atomic)
 
-  final def getByQuery(query: Query[T, DbModel, Seq], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Traversable[LwmModel]] =
+  final def getByQuery(query: Query[T, DbModel, Seq], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Seq[LwmModel]] =
     query.filterBy(validOnly, sinceLastModified)
       .retrieve(atomic)
 
-  final def getMany(ids: List[UUID], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Traversable[LwmModel]] =
+  final def getMany(ids: List[UUID], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Seq[LwmModel]] =
     tableQuery
       .filter(_.id.inSet(ids))
       .filterBy(validOnly, sinceLastModified)
@@ -65,7 +65,7 @@ trait Retrieved[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity,
       .retrieve(atomic)
       .map(_.headOption)
 
-  final def filter(where: T => Rep[Boolean], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Traversable[LwmModel]] =
+  final def filter(where: T => Rep[Boolean], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Seq[LwmModel]] =
     tableQuery
       .filter(where)
       .filterBy(validOnly, sinceLastModified)
@@ -76,7 +76,7 @@ trait Retrieved[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity,
   final def filterValidOnly(query: Query[T, DbModel, Seq]): Query[T, DbModel, Seq] = query.filterBy(validOnly = true, None)
 
   protected implicit class QueryOps(val query: Query[T, DbModel, Seq]) {
-    def retrieve(atomic: Boolean): Future[Traversable[LwmModel]] = if (atomic) toAtomic(query) else toUniqueEntity(query)
+    def retrieve(atomic: Boolean): Future[Seq[LwmModel]] = if (atomic) toAtomic(query) else toUniqueEntity(query)
 
     def filterBy(validOnly: Boolean, sinceLastModified: Option[String]): Query[T, DbModel, Seq] = query.filterLastModified(sinceLastModified).filterValidOnly(validOnly)
 

--- a/app/dao/helper/Retrieved.scala
+++ b/app/dao/helper/Retrieved.scala
@@ -34,6 +34,10 @@ trait Retrieved[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity,
     filterBy(tableFilter, validOnly, sinceLastModified)
       .retrieve(atomic)
 
+  final def getByQuery(query: Query[T, DbModel, Seq], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Traversable[LwmModel]] =
+    query.filterBy(validOnly, sinceLastModified)
+      .retrieve(atomic)
+
   final def getMany(ids: List[UUID], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Traversable[LwmModel]] =
     tableQuery
       .filter(_.id.inSet(ids))

--- a/app/dao/helper/Retrieved.scala
+++ b/app/dao/helper/Retrieved.scala
@@ -53,6 +53,14 @@ trait Retrieved[T <: Table[DbModel] with UniqueTable, DbModel <: UniqueDbEntity,
       .retrieve(atomic)
       .map(_.headOption)
 
+  final def getSingleWhere(where: T => Rep[Boolean], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Option[LwmModel]] =
+    tableQuery
+      .filter(where)
+      .take(1)
+      .filterBy(validOnly, sinceLastModified)
+      .retrieve(atomic)
+      .map(_.headOption)
+
   final def filter(where: T => Rep[Boolean], atomic: Boolean = true, validOnly: Boolean = true, sinceLastModified: Option[String] = None): Future[Traversable[LwmModel]] =
     tableQuery
       .filter(where)

--- a/app/database/TableHelper.scala
+++ b/app/database/TableHelper.scala
@@ -26,7 +26,9 @@ trait LabworkIdTable {
 
   def labworkFk = foreignKey("LABWORKS_fkey", labwork, TableQuery[LabworkTable])(_.id)
 
-  def memberOfCourse(course: String) = labworkFk.filter(_.course === UUID.fromString(course)).exists
+  def memberOfCourse(course: String) = memberOfCourses(List(UUID.fromString(course)))
+
+  def memberOfCourses(course: Traversable[UUID]) = labworkFk.filter(_.course.inSet(course)).exists
 }
 
 trait RoomIdTable {

--- a/app/database/helper/LdapUserStatus.scala
+++ b/app/database/helper/LdapUserStatus.scala
@@ -1,5 +1,7 @@
 package database.helper
 
+import play.api.libs.json.Writes
+
 import scala.util.{Failure, Success, Try}
 
 sealed trait LdapUserStatus {

--- a/app/models/Dashboard.scala
+++ b/app/models/Dashboard.scala
@@ -6,6 +6,7 @@ import scala.collection.Seq
 
 sealed trait Dashboard {
   def user: User
+
   def status: LdapUserStatus
 }
 
@@ -14,11 +15,11 @@ case class StudentDashboard(
   status: LdapUserStatus,
   semester: Semester,
   labworks: Seq[LabworkLike],
-  applications: Seq[LabworkApplicationLike],
-  groups: Seq[GroupLike],
-  cardEntries: Seq[ReportCardEntryLike],
-  evaluations: Seq[ReportCardEvaluationLike],
-  evaluationPatterns: Seq[ReportCardEvaluationPattern]
+  labworkApplications: Seq[LabworkApplicationLike],
+  groups: Seq[(String, LabworkLike)],
+  reportCardEntries: Seq[ReportCardEntryLike],
+  allEvaluations: Seq[ReportCardEvaluationLike],
+  passedEvaluations: Seq[(String, String, Boolean, Int)]
 ) extends Dashboard
 
 case class EmployeeDashboard(

--- a/app/models/Dashboard.scala
+++ b/app/models/Dashboard.scala
@@ -1,10 +1,17 @@
 package models
 
+import database.helper.LdapUserStatus
+
 import scala.collection.Traversable
 
-sealed trait Dashboard
+sealed trait Dashboard {
+  def user: User
+  def status: LdapUserStatus
+}
 
 case class StudentDashboard(
+  user: User,
+  status: LdapUserStatus,
   semester: Semester,
   labworks: Traversable[LabworkLike],
   applications: Traversable[LabworkApplicationLike],
@@ -15,6 +22,8 @@ case class StudentDashboard(
 ) extends Dashboard
 
 case class EmployeeDashboard(
+  user: User,
+  status: LdapUserStatus,
   semester: Semester,
   courses: Traversable[CourseAtom],
   scheduleEntries: Traversable[ScheduleEntryLike]

--- a/app/models/Dashboard.scala
+++ b/app/models/Dashboard.scala
@@ -2,7 +2,7 @@ package models
 
 import database.helper.LdapUserStatus
 
-import scala.collection.Traversable
+import scala.collection.Seq
 
 sealed trait Dashboard {
   def user: User
@@ -13,18 +13,18 @@ case class StudentDashboard(
   user: User,
   status: LdapUserStatus,
   semester: Semester,
-  labworks: Traversable[LabworkLike],
-  applications: Traversable[LabworkApplicationLike],
-  groups: Traversable[GroupLike],
-  cardEntries: Traversable[ReportCardEntryLike],
-  evaluations: Traversable[ReportCardEvaluationLike],
-  evaluationPatterns: Traversable[ReportCardEvaluationPattern]
+  labworks: Seq[LabworkLike],
+  applications: Seq[LabworkApplicationLike],
+  groups: Seq[GroupLike],
+  cardEntries: Seq[ReportCardEntryLike],
+  evaluations: Seq[ReportCardEvaluationLike],
+  evaluationPatterns: Seq[ReportCardEvaluationPattern]
 ) extends Dashboard
 
 case class EmployeeDashboard(
   user: User,
   status: LdapUserStatus,
   semester: Semester,
-  courses: Traversable[CourseAtom],
-  scheduleEntries: Traversable[ScheduleEntryLike]
+  courses: Seq[CourseAtom],
+  scheduleEntries: Seq[ScheduleEntryLike]
 ) extends Dashboard

--- a/app/models/ReportCardEntry.scala
+++ b/app/models/ReportCardEntry.scala
@@ -8,7 +8,12 @@ import play.api.libs.json._
 import utils.LwmDateTime._
 import utils.Ops.JsPathX
 
-sealed trait ReportCardEntryLike extends UniqueEntity
+sealed trait ReportCardEntryLike extends UniqueEntity {
+  def labworkId: UUID
+  def date: LocalDate
+  def start: LocalTime
+  def end: LocalTime
+}
 
 case class ReportCardEntry(
   student: UUID,
@@ -22,7 +27,9 @@ case class ReportCardEntry(
   rescheduled: Option[ReportCardRescheduled] = None,
   retry: Option[ReportCardRetry] = None,
   id: UUID = UUID.randomUUID
-) extends ReportCardEntryLike
+) extends ReportCardEntryLike {
+  override def labworkId = labwork
+}
 
 case class ReportCardEntryProtocol(
   student: UUID,
@@ -46,7 +53,9 @@ case class ReportCardEntryAtom(
   rescheduled: Option[ReportCardRescheduledAtom],
   retry: Option[ReportCardRetryAtom],
   id: UUID
-) extends ReportCardEntryLike
+) extends ReportCardEntryLike {
+  override def labworkId = labwork.id
+}
 
 object ReportCardEntry {
 

--- a/app/models/ReportCardEntryType.scala
+++ b/app/models/ReportCardEntryType.scala
@@ -21,6 +21,10 @@ object ReportCardEntryType {
 
   lazy val Supplement = ReportCardEntryType(AssignmentEntryType.Supplement.entryType)
 
+  lazy val BooleanBasedTypes = List(Attendance, Certificate, Supplement)
+
+  lazy val IntBasedTypes = List(Bonus)
+
   implicit val writes: Writes[ReportCardEntryType] = (
     (JsPath \ "entryType").write[String] and
       (JsPath \ "bool").write[Option[Boolean]] and

--- a/app/models/ReportCardEvaluation.scala
+++ b/app/models/ReportCardEvaluation.scala
@@ -9,13 +9,21 @@ import utils.LwmDateTime.writeDateTime
 
 sealed trait ReportCardEvaluationLike extends UniqueEntity {
   def lastModified: DateTime
+  def label: String
+  def bool: Boolean
+  def int: Int
+  def labworkId: UUID
 }
 
-case class ReportCardEvaluation(student: UUID, labwork: UUID, label: String, bool: Boolean, int: Int, lastModified: DateTime, id: UUID = UUID.randomUUID) extends ReportCardEvaluationLike
+case class ReportCardEvaluation(student: UUID, labwork: UUID, label: String, bool: Boolean, int: Int, lastModified: DateTime, id: UUID = UUID.randomUUID) extends ReportCardEvaluationLike {
+  override def labworkId = labwork
+}
 
 case class ReportCardEvaluationProtocol(student: UUID, labwork: UUID, label: String, bool: Boolean, int: Int)
 
-case class ReportCardEvaluationAtom(student: User, labwork: LabworkAtom, label: String, bool: Boolean, int: Int, lastModified: DateTime, id: UUID = UUID.randomUUID) extends ReportCardEvaluationLike
+case class ReportCardEvaluationAtom(student: User, labwork: LabworkAtom, label: String, bool: Boolean, int: Int, lastModified: DateTime, id: UUID = UUID.randomUUID) extends ReportCardEvaluationLike {
+  override def labworkId = labwork.id
+}
 
 object ReportCardEvaluation {
   implicit val writes: Writes[ReportCardEvaluation] = Json.writes[ReportCardEvaluation]

--- a/app/models/ScheduleEntry.scala
+++ b/app/models/ScheduleEntry.scala
@@ -8,11 +8,17 @@ import play.api.libs.json._
 import utils.LwmDateTime._
 import utils.Ops.JsPathX
 
-sealed trait ScheduleEntryLike extends UniqueEntity
+sealed trait ScheduleEntryLike extends UniqueEntity {
+  def labworkId: UUID
+}
 
-case class ScheduleEntry(labwork: UUID, start: LocalTime, end: LocalTime, date: LocalDate, room: UUID, supervisor: Set[UUID], group: UUID, id: UUID = UUID.randomUUID) extends ScheduleEntryLike
+case class ScheduleEntry(labwork: UUID, start: LocalTime, end: LocalTime, date: LocalDate, room: UUID, supervisor: Set[UUID], group: UUID, id: UUID = UUID.randomUUID) extends ScheduleEntryLike {
+  override def labworkId = labwork
+}
 
-case class ScheduleEntryAtom(labwork: LabworkAtom, start: LocalTime, end: LocalTime, date: LocalDate, room: Room, supervisor: Set[User], group: Group, id: UUID) extends ScheduleEntryLike
+case class ScheduleEntryAtom(labwork: LabworkAtom, start: LocalTime, end: LocalTime, date: LocalDate, room: Room, supervisor: Set[User], group: Group, id: UUID) extends ScheduleEntryLike {
+  override def labworkId = labwork.id
+}
 
 case class ScheduleEntryProtocol(labwork: UUID, start: LocalTime, end: LocalTime, date: LocalDate, room: UUID, supervisor: Set[UUID], group: UUID)
 

--- a/app/models/ScheduleEntry.scala
+++ b/app/models/ScheduleEntry.scala
@@ -10,6 +10,9 @@ import utils.Ops.JsPathX
 
 sealed trait ScheduleEntryLike extends UniqueEntity {
   def labworkId: UUID
+  def start: LocalTime
+  def end: LocalTime
+  def date: LocalDate
 }
 
 case class ScheduleEntry(labwork: UUID, start: LocalTime, end: LocalTime, date: LocalDate, room: UUID, supervisor: Set[UUID], group: UUID, id: UUID = UUID.randomUUID) extends ScheduleEntryLike {

--- a/app/models/Student.scala
+++ b/app/models/Student.scala
@@ -5,9 +5,18 @@ import java.util.UUID
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{JsPath, Json, Writes}
 
-case class Student(systemId: String, lastname: String, firstname: String, email: String, registrationId: String, enrollment: UUID, id: UUID = UUID.randomUUID) extends User
+trait StudentLike extends User {
+  def registrationId: String
+  def enrollmentId: UUID
+}
 
-case class StudentAtom(systemId: String, lastname: String, firstname: String, email: String, registrationId: String, enrollment: Degree, id: UUID) extends User
+case class Student(systemId: String, lastname: String, firstname: String, email: String, registrationId: String, enrollment: UUID, id: UUID = UUID.randomUUID) extends StudentLike {
+  override def enrollmentId = enrollment
+}
+
+case class StudentAtom(systemId: String, lastname: String, firstname: String, email: String, registrationId: String, enrollment: Degree, id: UUID) extends StudentLike {
+  override def enrollmentId = enrollment.id
+}
 
 object Student {
   implicit val writes: Writes[Student] = Json.writes[Student]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -58,11 +58,12 @@ database {
   connectionPool = HikariCP
   properties = {
     url = "jdbc:postgresql://localhost:5432/postgres"
+    user = ""
     databaseName = ""
     password = ""
   }
   # numThreads = 20 // The number of concurrent threads in the thread pool for asynchronous execution of database actions
   # queueSize = 1000 // The size of the queue for database actions which cannot be executed immediately when all threads are busy
   connectionTimeout = 5000 // The maximum time (ms) to wait before a call to getConnection is timed out
-  // keepAliveConnection = true // If this is set to true, one extra connection will be opened as soon as the database is accessed for the first time, and kept open until close() is called. This is useful for named in-memory databases in test environments.
+  # keepAliveConnection = true // If this is set to true, one extra connection will be opened as soon as the database is accessed for the first time, and kept open until close() is called. This is useful for named in-memory databases in test environments.
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,8 +17,13 @@ play {
     preflightMaxAge = 1 hour
   }
 
+  filters.hosts {
+    allowed = [".gm.fh-koeln.de:9000", "localhost:9000"]
+  }
+
   filters.disabled += play.filters.csrf.CSRFFilter
   filters.enabled += play.filters.cors.CORSFilter
+  play.filters.enabled += play.filters.hosts.AllowedHostsFilter
 }
 
 # LWM Settings (Custom)
@@ -56,8 +61,8 @@ database {
     databaseName = ""
     password = ""
   }
-  numThreads = 20 // The number of concurrent threads in the thread pool for asynchronous execution of database actions
-  queueSize = 1000 // The size of the queue for database actions which cannot be executed immediately when all threads are busy
+  # numThreads = 20 // The number of concurrent threads in the thread pool for asynchronous execution of database actions
+  # queueSize = 1000 // The size of the queue for database actions which cannot be executed immediately when all threads are busy
   connectionTimeout = 5000 // The maximum time (ms) to wait before a call to getConnection is timed out
   // keepAliveConnection = true // If this is set to true, one extra connection will be opened as soon as the database is accessed for the first time, and kept open until close() is called. This is useful for named in-memory databases in test environments.
 }

--- a/conf/routes
+++ b/conf/routes
@@ -148,7 +148,7 @@ GET           /labworks/:labwork/users/:user/buddies/:buddy                    c
 GET           /users/:id                                                       controllers.UserController.get(id)
 
 # Dashboard
-GET           /dashboard                                                      controllers.DashboardController.dashboard()
+GET           /dashboard                                                      controllers.DashboardController.dashboard(systemId: Option[String])
 
 # Map static resources from the /public folder to the /assets URL path
 GET           /assets/*file                                                    controllers.Assets.at(path="/public", file)

--- a/conf/routes
+++ b/conf/routes
@@ -148,7 +148,7 @@ GET           /labworks/:labwork/users/:user/buddies/:buddy                    c
 GET           /users/:id                                                       controllers.UserController.get(id)
 
 # Dashboard
-GET           /dashboards                                                      controllers.DashboardController.dashboard()
+GET           /dashboard                                                      controllers.DashboardController.dashboard()
 
 # Map static resources from the /public folder to the /assets URL path
 GET           /assets/*file                                                    controllers.Assets.at(path="/public", file)

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-#APP_CONF="conf/application.conf"
+APP_CONF="conf/application.conf"
 KEYCLOAK_CONF="conf/keycloak.json"
 
-#if git diff --cached --name-only | grep --quiet "$APP_CONF"
-#then
-#  git reset head $APP_CONF; git checkout -- $APP_CONF
-#fi
+if git diff --cached --name-only | grep --quiet "$APP_CONF"
+then
+  git reset head $APP_CONF; git checkout -- $APP_CONF
+fi
 
 if git diff --cached --name-only | grep --quiet "$KEYCLOAK_CONF"
 then

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-APP_CONF="conf/application.conf"
+#APP_CONF="conf/application.conf"
 KEYCLOAK_CONF="conf/keycloak.json"
 
-if git diff --cached --name-only | grep --quiet "$APP_CONF"
-then
-  git reset head $APP_CONF; git checkout -- $APP_CONF
-fi
+#if git diff --cached --name-only | grep --quiet "$APP_CONF"
+#then
+#  git reset head $APP_CONF; git checkout -- $APP_CONF
+#fi
 
 if git diff --cached --name-only | grep --quiet "$KEYCLOAK_CONF"
 then

--- a/test/auth/OAuthAuthorizationSpec.scala
+++ b/test/auth/OAuthAuthorizationSpec.scala
@@ -13,17 +13,22 @@ class OAuthAuthorizationSpec extends WordSpec with TestBaseDefinition with Guice
 
   "A OAuthAuthorization" should {
 
-    "extract bearer token from request when present" in {
-      val request = FakeRequest().withHeaders(("Authorization", "Bearer RANDOM_HASH"))
-      val maybeToken = auth.bearerToken(request)
+    "extract bearer token from request when present, regardless of capitalization" in {
+      val request1 = FakeRequest().withHeaders(("Authorization", "Bearer RANDOM_HASH"))
+      val maybeToken1 = auth.bearerToken(request1)
+      val request2 = FakeRequest().withHeaders(("Authorization", "bearer random_hash"))
+      val maybeToken2 = auth.bearerToken(request2)
 
-      maybeToken.value shouldBe "RANDOM_HASH"
+      maybeToken1.value shouldBe "RANDOM_HASH"
+      maybeToken2.value shouldBe "random_hash"
     }
 
     "not extract bearer token from request with wrong header configurations" in {
       auth.bearerToken(FakeRequest().withHeaders()) shouldBe None
       auth.bearerToken(FakeRequest().withHeaders(("fake", "fake"))) shouldBe None
       auth.bearerToken(FakeRequest().withHeaders(("Authorization", "fake"))) shouldBe None
+      auth.bearerToken(FakeRequest().withHeaders(("Authorization", "bearer"))) shouldBe None
+      auth.bearerToken(FakeRequest().withHeaders(("Authorization", "bearer "))) shouldBe None
     }
   }
 

--- a/test/base/LwmFakeApplication.scala
+++ b/test/base/LwmFakeApplication.scala
@@ -10,6 +10,7 @@ trait LwmFakeApplication {
 
   val fakeDbConfig = Configuration(
     "database.properties.url" -> "jdbc:postgresql://localhost:5432/postgres",
+    "database.properties.user" -> "alex",
     "database.properties.databaseName" -> "postgres",
     "database.properties.password" -> ""
   )

--- a/test/dao/SemesterDaoSpec.scala
+++ b/test/dao/SemesterDaoSpec.scala
@@ -1,13 +1,14 @@
 package dao
 
+import database.{SemesterDb, SemesterTable}
 import models.Semester
 import org.joda.time.LocalDate
-import slick.dbio.Effect.Write
-import database.{SemesterDb, SemesterTable}
 import play.api.inject.guice.GuiceableModule
+import slick.dbio.Effect.Write
 import slick.jdbc.PostgresProfile.api._
 
 final class SemesterDaoSpec extends AbstractDaoSpec[SemesterTable, SemesterDb, Semester] {
+
   import AbstractDaoSpec._
   import utils.LwmDateTime._
 
@@ -18,11 +19,10 @@ final class SemesterDaoSpec extends AbstractDaoSpec[SemesterTable, SemesterDb, S
   "A SemesterServiceSpec" should {
 
     "return current semester" in {
-      val current = dbEntities.map(_.toUniqueEntity).filter(Semester.isCurrent)
+      val current = dbEntities.map(_.toUniqueEntity).filter(Semester.isCurrent).head
 
-      async(dao.get(List(SemesterCurrentFilter))) { result =>
-        result.size shouldBe 1
-        result should contain theSameElementsAs current
+      async(dao.current(false)) { result =>
+        result.value shouldBe current
       }
     }
 
@@ -81,7 +81,7 @@ final class SemesterDaoSpec extends AbstractDaoSpec[SemesterTable, SemesterDb, S
 
   override protected val lwmAtom: Semester = dbEntity.toUniqueEntity
 
-  override protected val dao: AbstractDao[SemesterTable, SemesterDb, Semester] = app.injector.instanceOf(classOf[SemesterDao])
+  override protected val dao: SemesterDao = app.injector.instanceOf(classOf[SemesterDao])
 
   override protected def bindings: Seq[GuiceableModule] = Seq.empty
 }


### PR DESCRIPTION
resource is `/dashboard`

- improved dashboard semantic
- new query parameters
  - `numberOfUpcomingElements`: takes n entries for each labwork. default is none (ignore)
  - `entriesSinceNow`: returns entries which have their due since now . default is true
  - `sortedByDate`:  entries are sorted by date (first) and start time (second). default is true
  - `systemId`: returns dashboard of given user (dev only)