### PR TITLE
AbstractCRUDController API changes

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -7,6 +7,7 @@ import di._
 import javax.inject.Singleton
 import org.keycloak.adapters.KeycloakDeployment
 import play.api.{Configuration, Environment}
+import security.{SecurityActionChain, SecurityActionChainImpl}
 import service.actor.{ActorScheduler, BackupServiceActor, BlacklistApiServiceActor, SemesterCreationActor}
 import service.backup.{BackupService, PSQLBackupService}
 import service._
@@ -32,6 +33,8 @@ class Module(environment: Environment, implicit val config: Configuration) exten
     bind(classOf[MailerService]).toProvider(classOf[MailerServiceProvider])
 
     bind(classOf[SemesterService]).in(classOf[Singleton])
+
+    bind(classOf[SecurityActionChain]).to(classOf[SecurityActionChainImpl]).in(classOf[Singleton])
   }
 
   private def bindDaos(): Unit = {
@@ -57,6 +60,7 @@ class Module(environment: Environment, implicit val config: Configuration) exten
     bind(classOf[TimetableDao]).to(classOf[TimetableDaoImpl]).in(classOf[Singleton])
     bind(classOf[UserDao]).to(classOf[UserDaoImpl]).in(classOf[Singleton])
     bind(classOf[DashboardDao]).to(classOf[DashboardDaoImpl]).in(classOf[Singleton])
+    bind(classOf[LwmServiceDao]).to(classOf[LwmServiceDaoImpl]).in(classOf[Singleton])
   }
 
   private def bindActors(): Unit = {

--- a/app/controllers/AuthorityController.scala
+++ b/app/controllers/AuthorityController.scala
@@ -34,10 +34,10 @@ final class AuthorityController @Inject()(cc: ControllerComponents, val abstract
   override implicit val authorityDao: AuthorityDao = abstractDao
 
   override def delete(id: String, secureContext: SecureContext): Action[AnyContent] = contextFrom(Delete) asyncAction { _ =>
-    import utils.date.DateTimeOps.SqlTimestampConverter
-    import utils.date.DateTimeJsonFormatter.writeDateTime
-
-    abstractDao.deleteAuthorityIfNotBasic(UUID.fromString(id)).map(_.lastModified.dateTime).deleted
+    (for {
+      uuid <- id.uuidF
+      deleted <- abstractDao.deleteAuthorityIfNotBasic(uuid)
+    } yield deleted.toUniqueEntity).jsonResult
   }
 
   override protected def contextFrom: PartialFunction[Rule, SecureContext] = {

--- a/app/controllers/CourseController.scala
+++ b/app/controllers/CourseController.scala
@@ -74,7 +74,7 @@ final class CourseController @Inject()(cc: ControllerComponents, val abstractDao
     (for {
       course <- abstractDao.getSingle(uuid) if course.isDefined
       courseDb = course.map(_.asInstanceOf[Course]).map(toCourseDb).get
-      _ <- abstractDao.transaction(abstractDao.deleteQuery(uuid), authorityDao.deleteAssociatedAuthorities(courseDb))
+      _ <- abstractDao.transaction(abstractDao.deleteSingle(uuid), authorityDao.deleteAssociatedAuthorities(courseDb))
     } yield course).deleted
   }
 

--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -77,7 +77,7 @@ final class DashboardController @Inject()(
       entriesSinceNow = boolOf(request.queryString)(entriesSinceNowAttribute) getOrElse true
       sortedByDate = boolOf(request.queryString)(sortedByDateAttribute) getOrElse true
       board <- dashboardDao.dashboard(id)(atomic, numberOfUpcomingElements, entriesSinceNow, sortedByDate)
-    } yield board).jsonResult(d => Ok(Json.toJson(d)))
+    } yield board).jsonResult
   }
 
   override protected def contextFrom: PartialFunction[Rule, SecureContext] = {

--- a/app/controllers/DashboardController.scala
+++ b/app/controllers/DashboardController.scala
@@ -59,7 +59,10 @@ final class DashboardController @Inject()(
           )
         }
       )
-      case e: EmployeeDashboard => Json.writes[EmployeeDashboard].writes(e)
+      case e: EmployeeDashboard => {
+        import models.CourseAtom.writes
+        Json.writes[EmployeeDashboard].writes(e)
+      }
     }
   }
 

--- a/app/controllers/HomepageController.scala
+++ b/app/controllers/HomepageController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import javax.inject.{Inject, Singleton}
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.mvc._
 
@@ -10,7 +11,9 @@ class HomepageController @Inject()(cc: ControllerComponents) extends AbstractCon
   def index = Action {
     Ok(Json.obj(
       "status" -> "OK",
-      "message" -> "it works"
+      "message" -> "it works",
+      "app_name" -> Application.getClass.getPackage.getImplementationTitle,
+      "app_version" -> Application.getClass.getPackage.getImplementationVersion,
     ))
   }
 }

--- a/app/controllers/HomepageController.scala
+++ b/app/controllers/HomepageController.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import javax.inject.{Inject, Singleton}
-import play.api.Application
 import play.api.libs.json.Json
 import play.api.mvc._
 
@@ -11,9 +10,7 @@ class HomepageController @Inject()(cc: ControllerComponents) extends AbstractCon
   def index = Action {
     Ok(Json.obj(
       "status" -> "OK",
-      "message" -> "it works",
-      "app_name" -> Application.getClass.getPackage.getImplementationTitle,
-      "app_version" -> Application.getClass.getPackage.getImplementationVersion,
+      "message" -> "it works"
     ))
   }
 }

--- a/app/controllers/ReportCardEntryTypeController.scala
+++ b/app/controllers/ReportCardEntryTypeController.scala
@@ -25,12 +25,16 @@ class ReportCardEntryTypeController @Inject()(cc: ControllerComponents, val auth
   override protected implicit val reads: Reads[ReportCardEntryTypeProtocol] = ReportCardEntryTypeProtocol.reads
 
   def updateFrom(course: String, id: String) = restrictedContext(course)(Update) asyncAction { request =>
-    val uuid = UUID.fromString(id)
-
     (for {
+      uuid <- id.uuidF
       protocol <- Future.fromTry(parseJson(request))
       _ <- abstractDao.updateFields(uuid, protocol.bool, protocol.int)
-    } yield protocol).updated
+    } yield ReportCardEntryType(
+      protocol.entryType,
+      protocol.bool,
+      protocol.int,
+      uuid
+    )).jsonResult
   }
 
   override protected def restrictedContext(restrictionId: String): PartialFunction[Rule, SecureContext] = {

--- a/app/controllers/ReportCardEvaluationController.scala
+++ b/app/controllers/ReportCardEvaluationController.scala
@@ -89,7 +89,7 @@ final class ReportCardEvaluationController @Inject()(cc: ControllerComponents, v
     (for {
       existing <- abstractDao.get(list, atomic = false)
       deleted <- abstractDao.deleteMany(existing.map(_.id).toList)
-    } yield deleted).jsonResult
+    } yield deleted.map(_.toUniqueEntity)).jsonResult
   }
 
   private def evaluate(labwork: String, persistence: Boolean)(implicit request: Request[AnyContent]) = {
@@ -100,10 +100,16 @@ final class ReportCardEvaluationController @Inject()(cc: ControllerComponents, v
       existing <- abstractDao.get(List(labworkFilter(labworkId)), atomic = false)
 
       evaluated = ReportCardService.evaluateDeltas(cards.toList, patterns.toList, existing.toList)
-      _ <- if (persistence) abstractDao.createOrUpdateMany(evaluated) else Future.successful(Seq.empty)
+      _ <- if (persistence)
+        abstractDao.createOrUpdateMany(evaluated)
+      else
+        Future.successful(Seq.empty)
 
       atomic = extractAttributes(request.queryString, defaultAtomic = false)._2.atomic
-      evaluations <- if (atomic) abstractDao.getMany(evaluated.map(_.id), atomic) else Future.successful(evaluated.map(_.toUniqueEntity))
+      evaluations <- if (atomic)
+        abstractDao.getMany(evaluated.map(_.id), atomic)
+      else
+        Future.successful(evaluated.map(_.toUniqueEntity))
     } yield evaluations).jsonResult
   }
 

--- a/app/controllers/ReportCardEvaluationController.scala
+++ b/app/controllers/ReportCardEvaluationController.scala
@@ -89,7 +89,7 @@ final class ReportCardEvaluationController @Inject()(cc: ControllerComponents, v
     (for {
       existing <- abstractDao.get(list, atomic = false)
       deleted <- abstractDao.deleteMany(existing.map(_.id).toList)
-    } yield deleted).deleted
+    } yield deleted).jsonResult
   }
 
   private def evaluate(labwork: String, persistence: Boolean)(implicit request: Request[AnyContent]) = {

--- a/app/controllers/helper/JsonParser.scala
+++ b/app/controllers/helper/JsonParser.scala
@@ -17,6 +17,6 @@ trait JsonParser {
 
   private def unwrap(request: Request[AnyContent]): Try[JsValue] = request.body.asJson match {
     case Some(json) => Success(json)
-    case None => Failure(new Throwable("no json body"))
+    case None => Failure(new Throwable("json body is required"))
   }
 }

--- a/app/controllers/helper/ResultOps.scala
+++ b/app/controllers/helper/ResultOps.scala
@@ -1,7 +1,7 @@
 package controllers.helper
 
 import play.api.libs.json.Json.JsValueWrapper
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.{BaseController, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,82 +10,63 @@ import scala.util.control.NonFatal
 trait ResultOps {
   self: BaseController =>
 
+  private def errorJson(throwable: Throwable): JsValue = msgJson(throwable.getMessage)
+
+  private def msgJson(msg: String): JsValue = Json.obj("message" -> msg)
+
   protected def preconditionFailed(message: String): Result = PreconditionFailed(Json.obj("status" -> "KO", "message" -> message))
 
-  protected def internalServerError(throwable: Throwable): Result = InternalServerError(
-    Json.obj(
-      "status" -> "KO",
-      "message" -> throwable.getLocalizedMessage,
-      "stackTrace" -> throwable.getStackTrace.map(_.toString)
-    )
-  )
-
-
-  protected def badRequest(throwable: Throwable): Result = BadRequest(Json.obj(
-    "message" -> throwable.getMessage,
-    "stackTrace" -> throwable.getStackTrace.map(_.toString)
-  ))
+  protected def badRequest(throwable: Throwable): Result = BadRequest(errorJson(throwable))
 
   protected def ok[A](entity: A)(implicit writes: Writes[A]): Result = Ok(Json.toJson(entity))
 
   protected def ok(fields: (String, JsValueWrapper)*): Result = Ok(Json.obj(fields: _*))
 
-  protected def delete[A](entity: A)(implicit writes: Writes[A]): Result = Ok(Json.obj("deleted" -> Json.toJson(entity)))
+  protected def notFound(element: String): Result = NotFound(msgJson(s"No such element for $element"))
 
-  protected def update[A](entity: A)(implicit writes: Writes[A]): Result = Ok(Json.obj("updated" -> Json.toJson(entity)))
-
-  protected def notFound(element: String): Result = NotFound(Json.obj("status" -> "KO", "message" -> s"No such element for $element"))
+  private def recoverBadRequest(): PartialFunction[Throwable, Result] = {
+    case NonFatal(e) => badRequest(e)
+  }
 
   implicit class TraversableResult[A](val future: Future[Traversable[A]]) {
-    def jsonResult(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future.map(a => ok(a)).recover {
-      case NonFatal(e) => internalServerError(e)
-    }
-
-    def deleted(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future.map(a => delete(a)).recover {
-      case NonFatal(e) => internalServerError(e)
-    }
+    def jsonResult(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future
+      .map(a => ok(a))
+      .recover(recoverBadRequest())
   }
 
   implicit class OptionResult[A](val future: Future[Option[A]]) {
-    def jsonResult(idForMessage: String)(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future.map { maybeA =>
-      maybeA.fold(notFound(idForMessage))(a => ok(a))
-    }.recover {
-      case NonFatal(e) => internalServerError(e)
-    }
+    def jsonResult(idForMessage: String)(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future
+      .map(maybeA => maybeA.fold(notFound(idForMessage))(a => ok(a)))
+      .recover(recoverBadRequest())
   }
 
   implicit class CreatedResult[A](val future: Future[A]) {
-    def created(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future.map(a => Created(Json.toJson(a))).recover {
-      case NonFatal(e) => internalServerError(e)
-    }
+    def created(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future
+      .map(a => Created(Json.toJson(a)))
+      .recover(recoverBadRequest())
 
-    def deleted(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future.map(a => delete(a)).recover {
-      case NonFatal(e) => internalServerError(e)
-    }
+    def jsonResult(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future
+      .map(a => ok(a))
+      .recover(recoverBadRequest())
 
-    def updated(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future.map(a => update(a)).recover {
-      case NonFatal(e) => internalServerError(e)
-    }
-
-    def jsonResult(f: A => Result)(implicit executor: ExecutionContext): Future[Result] = future.map(f).recover {
-      case NonFatal(e) => internalServerError(e)
-    }
+    def jsonResult(f: A => Result)(implicit executor: ExecutionContext): Future[Result] = future
+      .map(f)
+      .recover(recoverBadRequest())
   }
 
   implicit class PartialResult[A](val future: Future[(Traversable[A], Traversable[A], List[Throwable])]) {
-    def jsonResult(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future.map { res =>
-      val (attempted, created, throwable) = res
-      val status = if (created.isEmpty) "KO" else if (throwable.isEmpty) "OK" else "Partial OK"
+    def jsonResult(implicit writes: Writes[A], executor: ExecutionContext): Future[Result] = future
+      .map { res =>
+        val (attempted, created, throwable) = res
+        val status = if (created.isEmpty) "KO" else if (throwable.isEmpty) "OK" else "Partial OK"
 
-      Ok(Json.obj(
-        "status" -> status,
-        "attempted" -> Json.toJson(attempted),
-        "created" -> Json.toJson(created),
-        "failed" -> Json.toJson(throwable.map(_.getLocalizedMessage))
-      ))
-    }.recover {
-      case NonFatal(e) => internalServerError(e)
-    }
+        ok(
+          "status" -> status,
+          "attempted" -> Json.toJson(attempted),
+          "created" -> Json.toJson(created),
+          "failed" -> Json.toJson(throwable.map(_.getLocalizedMessage))
+        )
+      }.recover(recoverBadRequest())
   }
 
 }

--- a/app/controllers/helper/ResultOps.scala
+++ b/app/controllers/helper/ResultOps.scala
@@ -1,5 +1,6 @@
 package controllers.helper
 
+import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json.{Json, Writes}
 import play.api.mvc.{BaseController, Result}
 
@@ -19,7 +20,15 @@ trait ResultOps {
     )
   )
 
+
+  protected def badRequest(throwable: Throwable): Result = BadRequest(Json.obj(
+    "message" -> throwable.getMessage,
+    "stackTrace" -> throwable.getStackTrace.map(_.toString)
+  ))
+
   protected def ok[A](entity: A)(implicit writes: Writes[A]): Result = Ok(Json.toJson(entity))
+
+  protected def ok(fields: (String, JsValueWrapper)*): Result = Ok(Json.obj(fields: _*))
 
   protected def delete[A](entity: A)(implicit writes: Writes[A]): Result = Ok(Json.obj("deleted" -> Json.toJson(entity)))
 

--- a/app/controllers/service/GroupChangeRequest.scala
+++ b/app/controllers/service/GroupChangeRequest.scala
@@ -1,0 +1,13 @@
+package controllers.service
+
+import java.util.UUID
+
+import play.api.libs.json.{Json, OWrites, Reads}
+
+case class GroupChangeRequest(labwork: UUID, student: UUID, group: UUID)
+
+object GroupChangeRequest {
+  implicit val writes: OWrites[GroupChangeRequest] = Json.writes[GroupChangeRequest]
+
+  implicit val reads: Reads[GroupChangeRequest] = Json.reads[GroupChangeRequest]
+}

--- a/app/controllers/service/GroupMovingRequest.scala
+++ b/app/controllers/service/GroupMovingRequest.scala
@@ -1,0 +1,12 @@
+package controllers.service
+
+import java.util.UUID
+
+import play.api.libs.json.{Json, OWrites, Reads}
+
+case class GroupMovingRequest(labwork: UUID, student: UUID, srcGroup: UUID, destGroup: UUID)
+
+object GroupMovingRequest {
+  implicit val writes: OWrites[GroupMovingRequest] = Json.writes[GroupMovingRequest]
+  implicit val reads: Reads[GroupMovingRequest] = Json.reads[GroupMovingRequest]
+}

--- a/app/controllers/service/LwmServiceController.scala
+++ b/app/controllers/service/LwmServiceController.scala
@@ -1,0 +1,89 @@
+package controllers.service
+
+import controllers.helper.{JsonParser, ResultOps, SecureControllerContext, Secured}
+import dao.{AuthorityDao, LwmServiceDao}
+import database.GroupMembership
+import javax.inject.Inject
+import models.Role.{CourseEmployee, CourseManager, God}
+import play.api.libs.json.{Json, OWrites}
+import play.api.mvc.{AbstractController, ControllerComponents, Result}
+import security.SecurityActionChain
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+final class LwmServiceController @Inject()(
+  cc: ControllerComponents,
+  val authorityDao: AuthorityDao,
+  val securedAction: SecurityActionChain,
+  val serviceDao: LwmServiceDao,
+  implicit val executionContext: ExecutionContext
+)
+  extends AbstractController(cc)
+    with Secured
+    with SecureControllerContext
+    with ResultOps
+    with JsonParser {
+
+  private implicit def membershipWrites: OWrites[GroupMembership] = Json.writes[GroupMembership]
+
+  def insertStudentToGroup(course: String) = restrictedContext(course)(Create) asyncAction { request =>
+    (parseJson[GroupChangeRequest] _ andThen mapJson andThen (r => r(insertIntoGroup))) (request)
+  }
+
+  def removeStudentFromGroup(course: String) = restrictedContext(course)(Delete) asyncAction { request =>
+    (parseJson[GroupChangeRequest] _ andThen mapJson andThen (r => r(removeFromGroup))) (request)
+  }
+
+  def moveStudentToGroup(course: String) = restrictedContext(course)(Update) asyncAction { request =>
+    (parseJson[GroupMovingRequest] _ andThen mapJson andThen (r => r(moveToGroup))) (request)
+  }
+
+  private def insertIntoGroup(request: GroupChangeRequest): Future[Result] = {
+    serviceDao.insertStudentToGroup(request.student, request.labwork, request.group).map {
+      case (membership, app, cards, _) => ok(
+        "labworkApplication" -> Json.toJson(app),
+        "membership" -> Json.toJson(membership),
+        "reportCardEntries" -> Json.toJson(cards)
+      )
+    }(executionContext)
+  }
+
+  private def removeFromGroup(request: GroupChangeRequest): Future[Result] = {
+    serviceDao.removeStudentFromGroup(request.student, request.labwork, request.group).map {
+      case (groupDeleted, deleteApp, deletedCards) => ok(
+        "changedMembership" -> Json.toJson(groupDeleted),
+        "labworkApplication" -> Json.toJson(deleteApp),
+        "reportCardEntries" -> Json.toJson(deletedCards)
+      )
+    }(executionContext)
+  }
+
+  private def moveToGroup(request: GroupMovingRequest): Future[Result] = {
+    serviceDao.moveStudentToGroup(request.student, request.labwork, request.srcGroup, request.destGroup).map {
+      case (groupDeleted, newMembership, _, _, updatedCards) => ok(
+        "changedMembership" -> Json.toJson(groupDeleted),
+        "newMembership" -> Json.toJson(newMembership),
+        "updatedReportCardEntries" -> Json.toJson(updatedCards)
+      )
+    }(executionContext)
+  }
+
+  private def mapJson[A](json: Try[A])(f: A => Future[Result]): Future[Result] = {
+    json match {
+      case Success(r) =>
+        f(r)
+      case Failure(e) =>
+        (badRequest _ andThen Future.successful) (e)
+    }
+  }
+
+  override protected def restrictedContext(restrictionId: String): PartialFunction[Rule, SecureContext] = {
+    case Update => SecureBlock(restrictionId, List(CourseEmployee, CourseManager))
+    case Create => SecureBlock(restrictionId, List(CourseManager))
+    case Delete => SecureBlock(restrictionId, List(CourseManager))
+    case _ => PartialSecureBlock(List(God))
+  }
+
+  override protected def contextFrom: PartialFunction[Rule, SecureContext] = forbiddenAction()
+}

--- a/app/controllers/serviceResource/GroupChangeRequest.scala
+++ b/app/controllers/serviceResource/GroupChangeRequest.scala
@@ -1,4 +1,4 @@
-package controllers.service
+package controllers.serviceResource
 
 import java.util.UUID
 

--- a/app/controllers/serviceResource/GroupMovingRequest.scala
+++ b/app/controllers/serviceResource/GroupMovingRequest.scala
@@ -1,4 +1,4 @@
-package controllers.service
+package controllers.serviceResource
 
 import java.util.UUID
 

--- a/app/controllers/serviceResource/LwmServiceController.scala
+++ b/app/controllers/serviceResource/LwmServiceController.scala
@@ -1,4 +1,4 @@
-package controllers.service
+package controllers.serviceResource
 
 import controllers.helper.{JsonParser, ResultOps, SecureControllerContext, Secured}
 import dao.{AuthorityDao, LwmServiceDao}
@@ -46,7 +46,7 @@ final class LwmServiceController @Inject()(
         "membership" -> Json.toJson(membership),
         "reportCardEntries" -> Json.toJson(cards)
       )
-    }(executionContext)
+    }
   }
 
   private def removeFromGroup(request: GroupChangeRequest): Future[Result] = {
@@ -56,7 +56,7 @@ final class LwmServiceController @Inject()(
         "labworkApplication" -> Json.toJson(deleteApp),
         "reportCardEntries" -> Json.toJson(deletedCards)
       )
-    }(executionContext)
+    }
   }
 
   private def moveToGroup(request: GroupMovingRequest): Future[Result] = {
@@ -66,7 +66,7 @@ final class LwmServiceController @Inject()(
         "newMembership" -> Json.toJson(newMembership),
         "updatedReportCardEntries" -> Json.toJson(updatedCards)
       )
-    }(executionContext)
+    }
   }
 
   private def mapJson[A](json: Try[A])(f: A => Future[Result]): Future[Result] = {

--- a/app/controllers/serviceResource/LwmServiceController.scala
+++ b/app/controllers/serviceResource/LwmServiceController.scala
@@ -27,6 +27,9 @@ final class LwmServiceController @Inject()(
 
   private implicit def membershipWrites: OWrites[GroupMembership] = Json.writes[GroupMembership]
 
+  import models.ReportCardEntry.{writes => cardWrites}
+  import models.LabworkApplication.{writes => lappWrites}
+
   def insertStudentToGroup(course: String) = restrictedContext(course)(Create) asyncAction { request =>
     (parseJson[GroupChangeRequest] _ andThen mapJson andThen (r => r(insertIntoGroup))) (request)
   }

--- a/app/dao/AuthorityDao.scala
+++ b/app/dao/AuthorityDao.scala
@@ -85,7 +85,7 @@ trait AuthorityDao extends AbstractDao[AuthorityTable, AuthorityDb, AuthorityLik
     val action = for {
       nonBasic <- query.exists.result
       d <- if (nonBasic)
-        deleteQuery(id)
+        deleteSingle(id)
       else
         DBIO.failed(new Throwable(s"The user associated with $id have to remain with at least one basic role, namely ${studentRole.label} or ${employeeRole.label}"))
     } yield d

--- a/app/dao/LwmServiceDao.scala
+++ b/app/dao/LwmServiceDao.scala
@@ -1,0 +1,99 @@
+package dao
+
+import java.util.UUID
+
+import dao.helper.{Core, TableFilter}
+import database._
+import javax.inject.Inject
+import models.{LabworkApplication, ReportCardEntry}
+import slick.jdbc.PostgresProfile.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait LwmServiceDao extends Core {
+
+  import TableFilter.{labworkFilter, userFilter}
+
+  protected def labworkApplicationDao: LabworkApplicationDao
+
+  protected def groupDao: GroupDao
+
+  protected def reportCardEntryDao: ReportCardEntryDao
+
+  def insertStudentToGroup(student: UUID, labwork: UUID, group: UUID): Future[(GroupMembership, LabworkApplication, Seq[ReportCardEntry], Option[UUID])] = {
+    val result = for {
+      membership <- groupDao.add(student, group)
+      maybeApp <- labworkApplicationDao.filterBy(List(labworkFilter(labwork), userFilter(student))).result.headOption
+      app <- maybeApp.fold(labworkApplicationDao.createQuery(LabworkApplicationDb(labwork, student, Set.empty)))(DBIO.successful)
+      srcStudent <- groupDao.firstStudentIn(group)
+      srcCards <- DBIO.sequenceOption(srcStudent.map(s => reportCards(labwork)(s).result))
+      copied = srcCards.getOrElse(Seq.empty).map { card =>
+        val newId = UUID.randomUUID
+        val newEntryTypes = card.entryTypes.map(t => ReportCardEntryTypeDb(Some(newId), None, t.entryType))
+
+        ReportCardEntryDb(student, labwork, card.label, card.date, card.start, card.end, card.room, newEntryTypes, card.assignmentIndex, id = newId)
+      }
+      destCards <- reportCardEntryDao.createManyQuery(copied)
+    } yield (membership, app.toUniqueEntity, destCards.map(_.toUniqueEntity), srcStudent)
+
+    db.run(result.transactionally)
+  }
+
+  def removeStudentFromGroup(student: UUID, labwork: UUID, group: UUID): Future[(Boolean, LabworkApplication, Seq[ReportCardEntry])] = {
+    val result = for {
+      shouldContinue <- groupDao.groupHasAtLeastTwoMembers(group)
+      _ <- ensure(shouldContinue, () => "there must be at least one member left after removal")
+
+      removedMembership <- groupDao.remove(student, group)
+      application = labworkApplicationDao.filterBy(List(labworkFilter(labwork), userFilter(student)))
+      removedApplication <- labworkApplicationDao.deleteSingleQuery(application)
+      cards <- reportCards(labwork)(student).result
+      removedCards <- DBIO.sequence(cards.map(c => reportCardEntryDao.deleteSingle(c.id)))
+    } yield (removedMembership > 0, removedApplication.toUniqueEntity, removedCards.map(_.toUniqueEntity))
+
+    db.run(result.transactionally)
+  }
+
+  def moveStudentToGroup(student: UUID, labwork: UUID, srcGroup: UUID, destGroup: UUID): Future[(Boolean, GroupMembership, Seq[ReportCardEntry], Seq[ReportCardEntry], Seq[ReportCardEntry])] = {
+    val reportCardFromLabwork = reportCards(labwork) _
+    val validCards = (cards: Seq[ReportCardEntryDb]) => cards.forall(_.assignmentIndex >= 0)
+
+    val result = for {
+      shouldContinue <- groupDao.groupHasAtLeastTwoMembers(srcGroup)
+      _ <- ensure(shouldContinue, () => "there must be at least one member left after moving")
+
+      maybeDestStudent <- groupDao.firstStudentIn(destGroup)
+      destStudent = maybeDestStudent.get
+      srcStudentCards <- reportCardFromLabwork(student).sortBy(_.assignmentIndex).result
+      destStudentCards <- reportCardFromLabwork(destStudent).sortBy(_.assignmentIndex).result
+      _ <- ensure(srcStudentCards.size == destStudentCards.size, () => "both src- and dest- reportCardEntries must have the same size")
+
+      removedMembership <- groupDao.remove(student, srcGroup)
+      newMembership <- groupDao.add(student, destGroup)
+
+      updatedSrcCards <- if (validCards(destStudentCards) && validCards(srcStudentCards)) {
+        val copiedCards = destStudentCards.zip(srcStudentCards)
+          .map { case (dest, src) => src.copy(date = dest.date, start = dest.start, end = dest.end, room = dest.room) }
+
+        DBIO.sequence(copiedCards.map(reportCardEntryDao.updateQuery))
+      } else
+        DBIO.failed(new Throwable("could not copy reportCardEntries because this operation is only supported on cards with a valid assignmentIndex"))
+    } yield (removedMembership > 0, newMembership, srcStudentCards.map(_.toUniqueEntity), destStudentCards.map(_.toUniqueEntity), updatedSrcCards.map(_.toUniqueEntity))
+
+    db.run(result.transactionally)
+  }
+
+  private def ensure(predicate: Boolean, orMsg: () => String): DBIOAction[Unit, NoStream, Effect] = if (predicate) DBIO.successful(()) else DBIO.failed(new Throwable(orMsg()))
+
+  private def reportCards(labwork: UUID)(student: UUID): Query[ReportCardEntryTable, ReportCardEntryDb, Seq] = {
+    reportCardEntryDao.filterBy(List(labworkFilter(labwork), userFilter(student)))
+  }
+}
+
+final class LwmServiceDaoImpl @Inject()(
+  val db: Database,
+  val executionContext: ExecutionContext,
+  val labworkApplicationDao: LabworkApplicationDao,
+  val groupDao: GroupDao,
+  val reportCardEntryDao: ReportCardEntryDao
+) extends LwmServiceDao

--- a/app/dao/ReportCardEntryDao.scala
+++ b/app/dao/ReportCardEntryDao.scala
@@ -54,6 +54,7 @@ trait ReportCardEntryDao extends AbstractDao[ReportCardEntryTable, ReportCardEnt
       entry.end.localTime,
       room.toUniqueEntity,
       entryTypes.map(_.toUniqueEntity).toSet,
+      entry.assignmentIndex,
       optRs.map { case (rs, r) => ReportCardRescheduledAtom(rs.date.localDate, rs.start.localTime, rs.end.localTime, r.toUniqueEntity, rs.reason, rs.id) },
       optRt.map { case (rt, r) => ReportCardRetryAtom(rt.date.localDate, rt.start.localTime, rt.end.localTime, r.toUniqueEntity, rt.entryTypes.map(_.toUniqueEntity), rt.reason, rt.id) },
       entry.id

--- a/app/dao/helper/DBError.scala
+++ b/app/dao/helper/DBError.scala
@@ -1,0 +1,15 @@
+package dao.helper
+
+sealed trait DBError extends Throwable
+
+object NoEntityFound extends DBError {
+  override def getMessage = "no entity found"
+}
+
+case class MultipleEntitiesFound[A](entities: Seq[A]) extends DBError {
+  override def getMessage = s"expected one entity, but found: $entities"
+}
+
+case class ModelAlreadyExists[A](value: A) extends DBError {
+  override def getMessage = s"model already exists $value"
+}

--- a/app/dao/helper/ModelAlreadyExists.scala
+++ b/app/dao/helper/ModelAlreadyExists.scala
@@ -1,5 +1,0 @@
-package dao.helper
-
-case class ModelAlreadyExists[A](value: A) extends Throwable {
-  override def getMessage = s"model already exists $value"
-}

--- a/app/database/ReportCardEntryTable.scala
+++ b/app/database/ReportCardEntryTable.scala
@@ -51,6 +51,7 @@ case class ReportCardEntryDb(
     end.localTime,
     room,
     entryTypes.map(_.toUniqueEntity),
+    assignmentIndex,
     rescheduled.map(_.toUniqueEntity),
     retry.map(_.toUniqueEntity),
     id

--- a/app/models/ReportCardEntry.scala
+++ b/app/models/ReportCardEntry.scala
@@ -10,8 +10,11 @@ import utils.date.DateTimeJsonFormatter._
 
 sealed trait ReportCardEntryLike extends UniqueEntity {
   def labworkId: UUID
+
   def date: LocalDate
+
   def start: LocalTime
+
   def end: LocalTime
 }
 
@@ -24,6 +27,7 @@ case class ReportCardEntry(
   end: LocalTime,
   room: UUID,
   entryTypes: Set[ReportCardEntryType],
+  assignmentIndex: Int,
   rescheduled: Option[ReportCardRescheduled] = None,
   retry: Option[ReportCardRetry] = None,
   id: UUID = UUID.randomUUID
@@ -50,6 +54,7 @@ case class ReportCardEntryAtom(
   end: LocalTime,
   room: Room,
   entryTypes: Set[ReportCardEntryType],
+  assignmentIndex: Int,
   rescheduled: Option[ReportCardRescheduledAtom],
   retry: Option[ReportCardRetryAtom],
   id: UUID
@@ -68,6 +73,7 @@ object ReportCardEntry {
       (JsPath \ "end").write[LocalTime] and
       (JsPath \ "room").write[UUID] and
       (JsPath \ "entryTypes").writeSet[ReportCardEntryType](ReportCardEntryType.writes) and
+      (JsPath \ "assignmentIndex").write[Int] and
       (JsPath \ "rescheduled").writeNullable[ReportCardRescheduled](ReportCardRescheduled.writes) and
       (JsPath \ "retry").writeNullable[ReportCardRetry](ReportCardRetry.writes) and
       (JsPath \ "id").write[UUID]
@@ -89,6 +95,7 @@ object ReportCardEntryAtom {
       (JsPath \ "end").write[LocalTime] and
       (JsPath \ "room").write[Room](Room.writes) and
       (JsPath \ "entryTypes").writeSet[ReportCardEntryType](ReportCardEntryType.writes) and
+      (JsPath \ "assignmentIndex").write[Int] and
       (JsPath \ "rescheduled").writeNullable[ReportCardRescheduledAtom](ReportCardRescheduledAtom.writes) and
       (JsPath \ "retry").writeNullable[ReportCardRetryAtom](ReportCardRetryAtom.writes) and
       (JsPath \ "id").write[UUID]

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -1,8 +1,6 @@
 import java.sql.Timestamp
 import java.util.UUID
 
-import play.api.libs.json.{JsValue, Json, Writes}
-
 package object models {
 
   trait UniqueEntity {
@@ -15,30 +13,6 @@ package object models {
     def invalidated: Option[Timestamp]
 
     def toUniqueEntity: UniqueEntity
-  }
-
-  implicit val uniqueEntityWrites: Writes[UniqueEntity] = {
-    case u: User => User.writes.writes(u)
-    case a: AssignmentPlanLike => AssignmentPlanLike.writes.writes(a)
-    case c: CourseLike => CourseLike.writes.writes(c)
-    case d: Degree => Degree.writes.writes(d)
-    case l: LabworkApplicationLike => LabworkApplicationLike.writes.writes(l)
-    case l: LabworkLike => LabworkLike.writes.writes(l)
-    case r: Role => Role.writes.writes(r)
-    case r: Room => Room.writes.writes(r)
-    case s: Semester => Semester.writes.writes(s)
-    case t: TimetableLike => TimetableLike.writes.writes(t)
-    case b: Blacklist => Blacklist.writes.writes(b)
-    case r: ReportCardEntry => ReportCardEntry.writes.writes(r)
-    case a: AuthorityLike => AuthorityLike.writes.writes(a)
-    case s: ScheduleEntryLike => ScheduleEntryLike.writes.writes(s)
-    case g: GroupLike => GroupLike.writes.writes(g)
-    case r: ReportCardEvaluationLike => ReportCardEvaluationLike.writes.writes(r)
-    case p: ReportCardEvaluationPattern => ReportCardEvaluationPattern.writes.writes(p)
-  }
-
-  object UniqueEntity {
-    def toJson[A <: UniqueEntity](seq: List[A]*)(implicit writes: Writes[A]): Seq[JsValue] = seq.map(a => Json.toJson(a))
   }
 
 }

--- a/app/security/SecurityActionChainImpl.scala
+++ b/app/security/SecurityActionChainImpl.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import java.util.concurrent.Executors
 
 import dao.RoleDao
-import javax.inject.{Inject, Singleton}
+import javax.inject.Inject
 import models.{Authority, LWMRole}
 import play.api.libs.json.Json
 import play.api.mvc.Results.Forbidden
@@ -12,8 +12,19 @@ import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-@Singleton
-final class SecurityActionChain @Inject()(authorizationAction: AuthorizationAction, authorityAction: AuthorityAction, roleDao: RoleDao) {
+trait SecurityActionChain {
+  protected def authorizationAction: AuthorizationAction
+
+  protected def authorityAction: AuthorityAction
+
+  protected def roleDao: RoleDao
+
+  def secured[R <: LWMRole](restricted: Option[UUID], required: List[R])(block: Request[AnyContent] => Result): Action[AnyContent]
+
+  def securedAsync[R <: LWMRole](restricted: Option[UUID], required: List[R])(block: Request[AnyContent] => Future[Result]): Action[AnyContent]
+}
+
+final class SecurityActionChainImpl @Inject()(val authorizationAction: AuthorizationAction, val authorityAction: AuthorityAction, val roleDao: RoleDao) extends SecurityActionChain {
 
   private implicit val actionExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool)
 
@@ -21,11 +32,11 @@ final class SecurityActionChain @Inject()(authorizationAction: AuthorizationActi
     authorizationAction andThen authorityAction andThen allowed(predicate)
   }
 
-  def secured[R <: LWMRole](restricted: Option[UUID], required: List[R])(block: Request[AnyContent] => Result) = {
+  def secured[R <: LWMRole](restricted: Option[UUID], required: List[R])(block: Request[AnyContent] => Result): Action[AnyContent] = {
     securedAction(authorities => roleDao.isAuthorized(restricted, required)(authorities)).apply(block)
   }
 
-  def securedAsync[R <: LWMRole](restricted: Option[UUID], required: List[R])(block: Request[AnyContent] => Future[Result]) = {
+  def securedAsync[R <: LWMRole](restricted: Option[UUID], required: List[R])(block: Request[AnyContent] => Future[Result]): Action[AnyContent] = {
     securedAction(authorities => roleDao.isAuthorized(restricted, required)(authorities)).async(block)
   }
 

--- a/app/service/ReportCardService.scala
+++ b/app/service/ReportCardService.scala
@@ -70,7 +70,7 @@ object ReportCardService { // TODO DI
           val entryId = UUID.randomUUID
           val types = ap.types.map(t => ReportCardEntryTypeDb(Some(entryId), None, t.entryType))
 
-          ReportCardEntryDb(student, assignmentPlan.labworkId, ap.label, se.date.sqlDate, se.start.sqlTime, se.end.sqlTime, se.room, types, id = entryId)
+          ReportCardEntryDb(student, assignmentPlan.labworkId, ap.label, se.date.sqlDate, se.start.sqlTime, se.end.sqlTime, se.room, types, ap.index, id = entryId)
       } ++ vec
     }
   }

--- a/conf/routes
+++ b/conf/routes
@@ -155,9 +155,9 @@ POST          /courses/:c/labworks/:l/mails                                    c
 GET           /dashboard                                                       controllers.DashboardController.dashboard(systemId: Option[String])
 
 # Service
-PUT           /courses/:c/insertIntoGroup                                      controllers.service.LwmServiceController.insertStudentToGroup(c)
-PUT           /courses/:c/removeFromGroup                                      controllers.service.LwmServiceController.removeStudentFromGroup(c)
-PUT           /courses/:c/moveToGroup                                          controllers.service.LwmServiceController.moveStudentToGroup(c)
+PUT           /courses/:c/insertIntoGroup                                      controllers.serviceResource.LwmServiceController.insertStudentToGroup(c)
+PUT           /courses/:c/removeFromGroup                                      controllers.serviceResource.LwmServiceController.removeStudentFromGroup(c)
+PUT           /courses/:c/moveToGroup                                          controllers.serviceResource.LwmServiceController.moveStudentToGroup(c)
 
 # Map static resources from the /public folder to the /assets URL path
 GET           /assets/*file                                                    controllers.Assets.at(path="/public", file)

--- a/conf/routes
+++ b/conf/routes
@@ -154,5 +154,10 @@ POST          /courses/:c/labworks/:l/mails                                    c
 # Dashboard
 GET           /dashboard                                                       controllers.DashboardController.dashboard(systemId: Option[String])
 
+# Service
+PUT           /courses/:c/insertIntoGroup                                      controllers.service.LwmServiceController.insertStudentToGroup(c)
+PUT           /courses/:c/removeFromGroup                                      controllers.service.LwmServiceController.removeStudentFromGroup(c)
+PUT           /courses/:c/moveToGroup                                          controllers.service.LwmServiceController.moveStudentToGroup(c)
+
 # Map static resources from the /public folder to the /assets URL path
 GET           /assets/*file                                                    controllers.Assets.at(path="/public", file)

--- a/test/base/AsyncSpec.scala
+++ b/test/base/AsyncSpec.scala
@@ -1,0 +1,9 @@
+package base
+
+import org.scalatest.time.{Seconds, Span}
+
+import scala.concurrent.Future
+
+trait AsyncSpec { self: TestBaseDefinition =>
+  final def async[R](future: Future[R])(assert: R => Unit): Unit = whenReady(future, timeout(Span(5, Seconds)))(assert)
+}

--- a/test/base/DatabaseSpec.scala
+++ b/test/base/DatabaseSpec.scala
@@ -8,13 +8,11 @@ import slick.jdbc.JdbcProfile
 
 import scala.concurrent.Future
 
-trait DatabaseSpec extends WordSpec with TestBaseDefinition with GuiceOneAppPerSuite with LwmFakeApplication {
+trait DatabaseSpec extends WordSpec with TestBaseDefinition with GuiceOneAppPerSuite with LwmFakeApplication with AsyncSpec {
   val db = app.injector.instanceOf(classOf[Database])
 
   val profile: JdbcProfile = _root_.slick.jdbc.PostgresProfile
   import profile.api._
-
-  protected final def async[R](future: Future[R])(assert: R => Unit): Unit = whenReady(future, timeout(Span(5, Seconds)))(assert)
 
   protected final def runAsync[R](action: DBIOAction[R, NoStream, Nothing])(assert: R => Unit): Unit = async(db.run(action))(assert)
 

--- a/test/base/DateGenerator.scala
+++ b/test/base/DateGenerator.scala
@@ -32,9 +32,9 @@ trait DateGenerator {
       year <- Gen.choose(1970, 2019)
       month <- Gen.choose(1, 12)
       day <- Gen.choose(1, 28)
-      hour <- Gen.choose(0, 23)
-      minute <- Gen.choose(0, 59)
-      second <- Gen.choose(0, 59)
+      hour <- Gen.choose(1, 23)
+      minute <- Gen.choose(1, 59)
+      second <- Gen.choose(1, 59)
     } yield dateTime(year, month, day, hour, minute, second, 0)
   }
 

--- a/test/base/DateGenerator.scala
+++ b/test/base/DateGenerator.scala
@@ -1,6 +1,6 @@
 package base
 
-import org.joda.time.{DateTime, LocalDate, LocalTime}
+import org.joda.time.{DateTime, DateTimeZone, LocalDate, LocalTime}
 import org.scalatest.Suite
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/test/base/LwmFakeApplication.scala
+++ b/test/base/LwmFakeApplication.scala
@@ -10,7 +10,7 @@ trait LwmFakeApplication {
 
   val fakeDbConfig = Configuration(
     "database.properties.url" -> "jdbc:postgresql://localhost:5432/postgres",
-    "database.properties.user" -> "alex",
+    "database.properties.user" -> "alexanderdobrynin",
     "database.properties.databaseName" -> "postgres",
     "database.properties.password" -> ""
   )

--- a/test/controllers/AbstractCRUDControllerSpec.scala
+++ b/test/controllers/AbstractCRUDControllerSpec.scala
@@ -1,0 +1,275 @@
+package controllers
+
+import java.sql.Timestamp
+import java.util.UUID
+
+import base.DatabaseSpec
+import dao.{AbstractDao, AuthorityDao}
+import database.UniqueTable
+import javax.inject.Inject
+import models.{UniqueDbEntity, UniqueEntity}
+import org.joda.time.DateTime
+import org.scalatest.mockito.MockitoSugar
+import play.api.inject.guice.GuiceableModule
+import play.api.libs.json._
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test._
+import security.SecurityActionChain
+import slick.jdbc.PostgresProfile
+import slick.jdbc.PostgresProfile.api._
+import utils.date.DateTimeOps.DateTimeConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class FakeProtocol(string: String, int: Int)
+
+case class FakeModel(string: String, int: Int, id: UUID) extends UniqueEntity
+
+class FakeTable(tag: Tag) extends Table[FakeDb](tag, "FAKE") with UniqueTable {
+  def string = column[String]("STRING")
+
+  def int = column[Int]("INT")
+
+  override def * = (string, int, lastModified, invalidated, id) <> ((FakeDb.apply _).tupled, FakeDb.unapply)
+}
+
+case class FakeDb(string: String, int: Int, lastModified: Timestamp = DateTime.now.timestamp, invalidated: Option[Timestamp] = None, id: UUID = UUID.randomUUID) extends UniqueDbEntity {
+  override def toUniqueEntity = FakeModel(string, int, id)
+}
+
+class FakeAbstractDao @Inject()(val db: Database, implicit val executionContext: ExecutionContext) extends AbstractDao[FakeTable, FakeDb, FakeModel] {
+  override protected val tableQuery = TableQuery[FakeTable]
+
+  override protected def toAtomic(query: PostgresProfile.api.Query[FakeTable, FakeDb, Seq]) = toUniqueEntity(query)
+
+  override protected def toUniqueEntity(query: PostgresProfile.api.Query[FakeTable, FakeDb, Seq]) = {
+    db.run(query.result.map(_.map(_.toUniqueEntity)))
+  }
+
+  override protected def existsQuery(entity: FakeDb): PostgresProfile.api.Query[FakeTable, FakeDb, Seq] = {
+    filterValidOnly(_.string === entity.string)
+  }
+
+  override protected def shouldUpdate(existing: FakeDb, toUpdate: FakeDb): Boolean = {
+    existing.int != toUpdate.int && existing.string == toUpdate.string
+  }
+}
+
+class FakeAbstractCRUDController @Inject()(
+  val cc: ControllerComponents,
+  val abstractDao: FakeAbstractDao,
+  val authorityDao: AuthorityDao,
+  val securedAction: SecurityActionChain
+) extends AbstractCRUDController[FakeProtocol, FakeTable, FakeDb, FakeModel](cc) {
+  override implicit protected def writes: Writes[FakeModel] = Json.writes[FakeModel]
+
+  override implicit protected def reads: Reads[FakeProtocol] = Json.reads[FakeProtocol]
+
+  override protected def toDbModel(protocol: FakeProtocol, existingId: Option[UUID]): FakeDb = {
+    FakeDb(protocol.string, protocol.int, id = existingId getOrElse UUID.randomUUID)
+  }
+
+  override protected def restrictedContext(restrictionId: String): PartialFunction[Rule, SecureContext] = {
+    case _ => NonSecureBlock
+  }
+
+  override protected def contextFrom: PartialFunction[Rule, SecureContext] = {
+    case _ => NonSecureBlock
+  }
+}
+
+class AbstractCRUDControllerSpec extends DatabaseSpec with MockitoSugar with Results {
+
+  override protected def bindings: Seq[GuiceableModule] = Seq.empty
+
+  val dao = new FakeAbstractDao(
+    db,
+    app.injector.instanceOf(classOf[ExecutionContext])
+  )
+
+  val controller = new FakeAbstractCRUDController(
+    app.injector.instanceOf(classOf[ControllerComponents]),
+    dao,
+    app.injector.instanceOf(classOf[AuthorityDao]),
+    app.injector.instanceOf(classOf[SecurityActionChain]),
+  )
+
+  val items = (0 until 10).map(i => FakeDb(i.toString, i)).toList
+
+  private def contentAsJsonMessage(result: Future[Result]) = {
+    contentAsJson(result).\("message").get
+  }
+
+  implicit val writesP: OWrites[FakeProtocol] = Json.writes[FakeProtocol]
+
+  implicit val writesM: OWrites[FakeModel] = Json.writes[FakeModel]
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    async(dao.createSchema)(_ => Unit)
+    async(dao.createMany(items))(_ => Unit)
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+
+    async(dao.dropSchema)(_ => Unit)
+  }
+
+  "A AbstractCRUDControllerSpec" should {
+
+    "return all values" in {
+      val request = FakeRequest()
+      val result = controller.all().apply(request)
+
+      status(result) shouldBe OK
+      contentAsJson(result) shouldBe a[JsArray]
+    }
+
+    "fail a get request if filter are bad" in {
+      val request = FakeRequest("GET", "?foo=bar")
+      val result = controller.all().apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result) shouldBe JsString("no filter for foo and bar")
+    }
+
+    "return get a single value" in {
+      val request = FakeRequest()
+      val result = controller.get(items.head.id.toString).apply(request)
+
+      status(result) shouldBe OK
+      contentAsJson(result) shouldBe a[JsObject]
+    }
+
+    "return no value if not found" in {
+      val request = FakeRequest()
+      val id = UUID.randomUUID.toString
+      val result = controller.get(id).apply(request)
+
+      status(result) shouldBe NOT_FOUND
+      contentAsJsonMessage(result) shouldBe JsString(s"No such element for $id")
+    }
+
+    "fail to get a single value if id is broken" in {
+      val request = FakeRequest()
+      val result = controller.get("broken").apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result) shouldBe JsString("Invalid UUID string: broken")
+    }
+
+    "create a new value" in {
+      val json = JsArray(Seq(Json.toJson(FakeProtocol("fake", 0))))
+      val request = FakeRequest().withJsonBody(json)
+      val result = controller.create().apply(request)
+
+      status(result) shouldBe OK
+
+      val createdJson = contentAsJson(result).\("created").as[JsArray].\(0)
+      createdJson.\("string").get shouldBe JsString("fake")
+      createdJson.\("int").get shouldBe JsNumber(0)
+      createdJson.\("id").get shouldBe a[JsString]
+    }
+
+    "fail creation if body is bad json" in {
+      val request = FakeRequest().withJsonBody(JsArray(Seq(JsString(""))))
+      val result = controller.create().apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result).toString() should include("error.expected")
+    }
+
+    "fail creation if there is no body " in {
+      val request = FakeRequest()
+      val result = controller.create().apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result) shouldBe JsString("json body is required")
+    }
+
+    "update a value" in {
+      val first = items.head
+      val body = FakeProtocol(first.string, 3201)
+      val request = FakeRequest().withJsonBody(Json.toJson(body))
+      val result = controller.update(first.id.toString).apply(request)
+
+      status(result) shouldBe OK
+      contentAsJson(result).\("updated").get shouldBe Json.toJson(FakeModel(body.string, body.int, first.id))
+    }
+
+    "fail update if model already exists" in {
+      val first = items.head
+      val body = FakeProtocol("can't update that", -1)
+      val request = FakeRequest().withJsonBody(Json.toJson(body))
+      val result = controller.update(first.id.toString).apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result).toString should include("model already exists")
+    }
+
+    "fail update if json is bad" in {
+      val first = items.head
+      val request = FakeRequest().withJsonBody(JsString(""))
+      val result = controller.update(first.id.toString).apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result).toString should include("error.expected")
+    }
+
+    "fail update if there is no body" in {
+      val first = items.head
+      val request = FakeRequest()
+      val result = controller.update(first.id.toString).apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result).toString should include("json body is required")
+    }
+
+    "fail update if value can't be found" in {
+      val first = items.head
+      val body = FakeProtocol(first.string, 3201)
+      val request = FakeRequest().withJsonBody(Json.toJson(body))
+      val result = controller.update(UUID.randomUUID.toString).apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result) shouldBe JsString("Invoker.first") // TODO super wrong
+    }
+
+    "fail update if id is broken" in {
+      val first = items.head
+      val body = FakeProtocol(first.string, 3201)
+      val request = FakeRequest().withJsonBody(Json.toJson(body))
+      val result = controller.update("broken").apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result) shouldBe JsString("Invalid UUID string: broken")
+    }
+
+    "delete a value" in {
+      val request = FakeRequest()
+      val item = items(1)
+      val result = controller.delete(item.id.toString).apply(request)
+
+      status(result) shouldBe OK
+      contentAsJson(result).\("deleted").get shouldBe Json.toJson(item.toUniqueEntity)
+    }
+
+    "fail delete if value is not found" in {
+      val request = FakeRequest()
+      val result = controller.delete(UUID.randomUUID.toString).apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR // TODO this is wrong
+    }
+
+    "fail delete if id is bad" in {
+      val request = FakeRequest()
+      val result = controller.delete("broken").apply(request)
+
+      status(result) shouldBe INTERNAL_SERVER_ERROR
+      contentAsJsonMessage(result) shouldBe JsString("Invalid UUID string: broken")
+    }
+  }
+}

--- a/test/controllers/FakeAbstractCRUDController.scala
+++ b/test/controllers/FakeAbstractCRUDController.scala
@@ -1,0 +1,75 @@
+package controllers
+
+import java.sql.Timestamp
+import java.util.UUID
+
+import dao.{AbstractDao, AuthorityDao}
+import database.UniqueTable
+import javax.inject.Inject
+import models.{UniqueDbEntity, UniqueEntity}
+import org.joda.time.DateTime
+import play.api.libs.json.{Json, Reads, Writes}
+import play.api.mvc.ControllerComponents
+import security.SecurityActionChain
+import slick.jdbc.PostgresProfile
+import slick.jdbc.PostgresProfile.api._
+import utils.date.DateTimeOps.DateTimeConverter
+
+import scala.concurrent.ExecutionContext
+
+case class FakeProtocol(string: String, int: Int)
+
+case class FakeModel(string: String, int: Int, id: UUID) extends UniqueEntity
+
+class FakeTable(tag: Tag) extends Table[FakeDb](tag, "FAKE") with UniqueTable {
+  def string = column[String]("STRING")
+
+  def int = column[Int]("INT")
+
+  override def * = (string, int, lastModified, invalidated, id) <> ((FakeDb.apply _).tupled, FakeDb.unapply)
+}
+
+case class FakeDb(string: String, int: Int, lastModified: Timestamp = DateTime.now.timestamp, invalidated: Option[Timestamp] = None, id: UUID = UUID.randomUUID) extends UniqueDbEntity {
+  override def toUniqueEntity = FakeModel(string, int, id)
+}
+
+class FakeAbstractDao @Inject()(val db: Database, implicit val executionContext: ExecutionContext) extends AbstractDao[FakeTable, FakeDb, FakeModel] {
+  override protected val tableQuery = TableQuery[FakeTable]
+
+  override protected def toAtomic(query: PostgresProfile.api.Query[FakeTable, FakeDb, Seq]) = toUniqueEntity(query)
+
+  override protected def toUniqueEntity(query: PostgresProfile.api.Query[FakeTable, FakeDb, Seq]) = {
+    db.run(query.result.map(_.map(_.toUniqueEntity)))
+  }
+
+  override protected def existsQuery(entity: FakeDb): PostgresProfile.api.Query[FakeTable, FakeDb, Seq] = {
+    filterValidOnly(_.string === entity.string)
+  }
+
+  override protected def shouldUpdate(existing: FakeDb, toUpdate: FakeDb): Boolean = {
+    existing.int != toUpdate.int && existing.string == toUpdate.string
+  }
+}
+
+class FakeAbstractCRUDController @Inject()(
+  val cc: ControllerComponents,
+  val abstractDao: FakeAbstractDao,
+  val authorityDao: AuthorityDao,
+  val securedAction: SecurityActionChain
+) extends AbstractCRUDController[FakeProtocol, FakeTable, FakeDb, FakeModel](cc) {
+  override implicit protected def writes: Writes[FakeModel] = Json.writes[FakeModel]
+
+  override implicit protected def reads: Reads[FakeProtocol] = Json.reads[FakeProtocol]
+
+  override protected def toDbModel(protocol: FakeProtocol, existingId: Option[UUID]): FakeDb = {
+    FakeDb(protocol.string, protocol.int, id = existingId getOrElse UUID.randomUUID)
+  }
+
+  override protected def restrictedContext(restrictionId: String): PartialFunction[Rule, SecureContext] = {
+    case _ => NonSecureBlock
+  }
+
+  override protected def contextFrom: PartialFunction[Rule, SecureContext] = {
+    case _ => NonSecureBlock
+  }
+}

--- a/test/dao/AbstractReportCardEntryDaoSpec.scala
+++ b/test/dao/AbstractReportCardEntryDaoSpec.scala
@@ -27,6 +27,7 @@ final class AbstractReportCardEntryDaoSpec extends AbstractExpandableDaoSpec[Rep
     entry.end.localTime,
     rooms.find(_.id == entry.room).get.toUniqueEntity,
     entry.entryTypes.map(_.toUniqueEntity),
+    entry.assignmentIndex,
     entry.rescheduled.map(r =>
       ReportCardRescheduledAtom(r.date.localDate, r.start.localTime, r.end.localTime, rooms.find(_.id == r.room).get.toUniqueEntity, r.reason, r.id)
     ),

--- a/test/dao/AbstractReportCardEntryDaoSpec.scala
+++ b/test/dao/AbstractReportCardEntryDaoSpec.scala
@@ -16,7 +16,7 @@ final class AbstractReportCardEntryDaoSpec extends AbstractExpandableDaoSpec[Rep
   import scala.concurrent.ExecutionContext.Implicits.global
 
   private lazy val privateLabs = populateLabworks(20)(semesters, courses, degrees)
-  private lazy val privateStudents = populateStudents(100)
+  private lazy val privateStudents = populateStudents(100)(degrees)
 
   def reportCardEntryAtom(entry: ReportCardEntryDb)(labworks: List[LabworkDb], students: List[UserDb], rooms: List[RoomDb]) = ReportCardEntryAtom(
     students.find(_.id == entry.student).get.toUniqueEntity,
@@ -38,7 +38,7 @@ final class AbstractReportCardEntryDaoSpec extends AbstractExpandableDaoSpec[Rep
 
   override protected def name: String = "reportCardEntry"
 
-  override protected val dbEntity: ReportCardEntryDb = ReportCardEntryDb(students.head.id, labworks.head.id, "label", Date.valueOf("1990-05-02"), Time.valueOf("17:00:00"), Time.valueOf("18:00:00"), rooms.head.id, Set.empty)
+  override protected val dbEntity: ReportCardEntryDb = ReportCardEntryDb(students.head.id, labworks.head.id, "label", Date.valueOf("1990-05-02"), Time.valueOf("17:00:00"), Time.valueOf("18:00:00"), rooms.head.id, Set.empty, 1)
 
   override protected val invalidDuplicateOfDbEntity: ReportCardEntryDb = dbEntity
 

--- a/test/dao/AuthorityDaoSpec.scala
+++ b/test/dao/AuthorityDaoSpec.scala
@@ -144,9 +144,9 @@ class AuthorityDaoSpec extends AbstractDaoSpec[AuthorityTable, AuthorityDb, Auth
         TableQuery[CourseTable].forceInsertAll(List(course1, course2)),
         dao.createManyQuery(auths),
         dao.isCourseManager(lecturer.id) map (_ shouldBe true),
-        dao.deleteQuery(auths(1).id),
+        dao.deleteSingle(auths(1).id),
         dao.isCourseManager(lecturer.id) map (_ shouldBe true),
-        dao.deleteQuery(auths(2).id),
+        dao.deleteSingle(auths(2).id),
         dao.isCourseManager(lecturer.id) map (_ shouldBe false)
       )
     }

--- a/test/dao/GroupDaoSpec.scala
+++ b/test/dao/GroupDaoSpec.scala
@@ -15,14 +15,14 @@ final class GroupDaoSpec extends AbstractExpandableDaoSpec[GroupTable, GroupDb, 
   import scala.concurrent.ExecutionContext.Implicits.global
   import scala.util.Random.{nextBoolean, nextInt, shuffle}
 
-  private lazy val privateStudents = populateStudents(20 * 8 * 2)
+  private lazy val privateStudents = populateStudents(20 * 8 * 2)(degrees)
   private lazy val privateLabs = populateLabworks(10)(semesters, courses, degrees)
 
   private def takeSomeStudents(amount: Int) = shuffle(privateStudents) take (if (nextBoolean) amount + nextInt(3) else amount - nextInt(3))
 
   "A GroupDaoSpec also" should {
     "filter by students properly" in {
-      val superPrivateStudents = populateStudents(3)
+      val superPrivateStudents = populateStudents(3)(degrees)
       val superPrivateStudent1 = superPrivateStudents(0)
       val superPrivateStudent2 = superPrivateStudents(1)
       val superPrivateStudent3 = superPrivateStudents(2)

--- a/test/dao/LabworkApplicationDaoSpec.scala
+++ b/test/dao/LabworkApplicationDaoSpec.scala
@@ -45,7 +45,7 @@ class LabworkApplicationDaoSpec extends AbstractExpandableDaoSpec[LabworkApplica
 
   private val expandedLabworks = labworks drop 5
 
-  private val expandedStudents = populateStudents(100)
+  private val expandedStudents = populateStudents(100)(degrees)
 
   private def randomAvoiding(element: UUID, source: List[UUID], atLeastOne: Boolean): Set[UUID] = {
     random(source.filterNot(_ == element), atLeastOne)

--- a/test/dao/LwmServiceDaoSpec.scala
+++ b/test/dao/LwmServiceDaoSpec.scala
@@ -1,0 +1,428 @@
+package dao
+
+import java.util.UUID
+
+import base.{DateGenerator, PostgresDbSpec}
+import dao.helper.TableFilter.{userFilter, labworkFilter}
+import database._
+import database.helper.LdapUserStatus.StudentStatus
+import play.api.inject.guice.GuiceableModule
+import slick.dbio.{DBIOAction, Effect, NoStream}
+import slick.jdbc.PostgresProfile.api._
+import utils.date.DateTimeOps.{LocalDateConverter, LocalTimeConverter, localDateOrd}
+
+class LwmServiceDaoSpec extends PostgresDbSpec with DateGenerator {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  val dao = app.injector.instanceOf(classOf[LwmServiceDao])
+  val groupDap = app.injector.instanceOf(classOf[GroupDao])
+  val reportCardEntryDao = app.injector.instanceOf(classOf[ReportCardEntryDao])
+  val labworkApplicationDao = app.injector.instanceOf(classOf[LabworkApplicationDao])
+
+  private val rooms = AbstractDaoSpec.rooms
+  private val degrees = AbstractDaoSpec.populateDegrees(2)
+  private val students = AbstractDaoSpec.populateStudents(100)(degrees)
+  private val employees = AbstractDaoSpec.employees
+  private val users = employees ++ students
+  private val semesters = AbstractDaoSpec.populateSemester(1)
+  private val courses = AbstractDaoSpec.populateCourses(1)(_ => 1)
+  private val labworks = AbstractDaoSpec.populateLabworks(3)(semesters, courses, degrees)
+  private val applications = AbstractDaoSpec.populateLabworkApplications(students.size, true)(labworks, students)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+
+    val clear = for {
+      gs <- groupDap.get()
+      _ <- groupDap.deleteMany(gs.map(_.id).toList)
+      crds <- reportCardEntryDao.get()
+      _ <- reportCardEntryDao.deleteMany(crds.map(_.id).toList)
+    } yield Unit
+
+
+    async(clear)(_ => Unit)
+  }
+
+  "A LwmServiceDao" should {
+
+    "insert a student into an existing group even if an application exists" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      val groups = createGroups
+      val reportCardEntries = createReportCardEntries(groups).filterNot(_.labwork == labwork.id)
+      val application = LabworkApplicationDb(labwork.id, student.id, Set.empty)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+      async(labworkApplicationDao.create(application))(_ => Unit)
+
+      val destGrp = groups.find(_.labwork == labwork.id).get
+
+      async(dao.insertStudentToGroup(student.id, labwork.id, destGrp.id)) {
+        case (membership, lapp, cards, srcStudent) =>
+          lapp shouldBe application.toUniqueEntity
+
+          membership.student shouldBe student.id
+          membership.group shouldBe destGrp.id
+
+          srcStudent.isDefined shouldBe true
+          cards shouldBe empty
+      }
+    }
+
+    "insert a student into an existing group by creating a new application" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      val added = GroupDb("foo", labworks.find(_.id != labwork.id).get.id, Set(student.id))
+      val groups = createGroups :+ added
+      val reportCardEntries = createReportCardEntries(groups).filterNot(_.labwork == labwork.id)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+
+      val destGrp = groups.find(_.labwork == labwork.id).get
+
+      async(dao.insertStudentToGroup(student.id, labwork.id, destGrp.id)) {
+        case (membership, lapp, cards, srcStudent) =>
+          lapp.labwork shouldBe labwork.id
+          lapp.applicant shouldBe student.id
+          lapp.friends shouldBe empty
+
+          membership.student shouldBe student.id
+          membership.group shouldBe destGrp.id
+
+          srcStudent.isDefined shouldBe true
+          cards shouldBe empty
+      }
+    }
+
+    "insert a student into an existing group by creating a new application and copying reportCardEntries" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      val groups = createGroups
+      val reportCardEntries = createReportCardEntries(groups)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+
+      val destGrp = groups.find(_.labwork == labwork.id).get
+
+      async(dao.insertStudentToGroup(student.id, labwork.id, destGrp.id)) {
+        case (membership, lapp, cards, srcStudent) =>
+          lapp.labwork shouldBe labwork.id
+          lapp.applicant shouldBe student.id
+          lapp.friends shouldBe empty
+
+          membership.student shouldBe student.id
+          membership.group shouldBe destGrp.id
+
+          val lhs = cards
+            .sortBy(_.date)
+
+          lhs.forall(r => r.labwork == labwork.id && r.student == student.id && r.rescheduled.isEmpty && r.retry.isEmpty && r.entryTypes.forall(_.bool.isEmpty)) shouldBe true
+
+          val rhs = reportCardEntries
+            .filter(_.student == srcStudent.get)
+            .map(_.toUniqueEntity)
+            .sortBy(_.date)
+
+          lhs.size shouldBe rhs.size
+          lhs.zip(rhs).foreach {
+            case (l, r) =>
+              l.student should not be r.student
+              l.id should not be r.id
+
+              l.labwork shouldBe r.labwork
+              l.date shouldBe r.date
+              l.start shouldBe r.start
+              l.end shouldBe r.end
+              l.room shouldBe r.room
+          }
+      }
+    }
+
+    "fail inserting a student into an existing group if he has already one" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      val groups = createGroups
+      val destGrp = groups.find(_.labwork == labwork.id).get
+      val added = destGrp.copy(members = destGrp.members + student.id)
+
+      val reportCardEntries = createReportCardEntries(groups).filterNot(_.labwork == labwork.id)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+      async(groupDap.update(added))(_ => Unit)
+
+      async(dao.insertStudentToGroup(student.id, labwork.id, destGrp.id).failed) { error =>
+        error.getMessage shouldBe s"student ${student.id} is already in group ${destGrp.id}"
+      }
+    }
+
+    "remove a student from an existing group by removing application, membership and reportCardEntries" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var group = groups.find(_.labwork == labwork.id).get
+      group = group.copy(members = group.members + student.id)
+      groups = groups.map(g => if (g.id == group.id) group else g)
+
+      val reportCardEntries = createReportCardEntries(groups)
+      val application = LabworkApplicationDb(labwork.id, student.id, Set.empty)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+      async(labworkApplicationDao.create(application))(_ => Unit)
+
+      async(dao.removeStudentFromGroup(student.id, labwork.id, group.id)) {
+        case (deletedGrp, deletedLapp, deletedCards) =>
+          deletedGrp shouldBe true
+
+          deletedLapp.applicant shouldBe student.id
+          deletedLapp.labwork shouldBe labwork.id
+
+          deletedCards should not be empty
+          deletedCards.forall(c => c.student == student.id && c.labwork == labwork.id) shouldBe true
+      }
+
+      async(labworkApplicationDao.getSingle(application.id))(_.isEmpty shouldBe true)
+      runAsync(groupDap.isInGroup(student.id, group.id))(_ shouldBe false)
+      async(reportCardEntryDao.get(List(labworkFilter(labwork.id), userFilter(student.id))))(_.isEmpty shouldBe true)
+    }
+
+    "remove a student from an existing group even if no reportCardEntries exists" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var group = groups.find(_.labwork == labwork.id).get
+      group = group.copy(members = group.members + student.id)
+      groups = groups.map(g => if (g.id == group.id) group else g)
+
+      val reportCardEntries = createReportCardEntries(groups).filterNot(_.labwork == labwork.id)
+      val application = LabworkApplicationDb(labwork.id, student.id, Set.empty)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+      async(labworkApplicationDao.create(application))(_ => Unit)
+
+      async(dao.removeStudentFromGroup(student.id, labwork.id, group.id)) {
+        case (deletedGrp, deletedLapp, deletedCards) =>
+          deletedGrp shouldBe true
+
+          deletedLapp.applicant shouldBe student.id
+          deletedLapp.labwork shouldBe labwork.id
+
+          deletedCards shouldBe empty
+      }
+
+      async(labworkApplicationDao.getSingle(application.id))(_.isEmpty shouldBe true)
+      runAsync(groupDap.isInGroup(student.id, group.id))(_ shouldBe false)
+      async(reportCardEntryDao.get(List(labworkFilter(labwork.id), userFilter(student.id))))(_.isEmpty shouldBe true)
+    }
+
+    "fail removing a student from a group if he is no member of that group" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      val groups = createGroups
+      val group = groups.find(g => g.labwork == labwork.id && !g.members.contains(student.id)).get
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+
+      async(dao.removeStudentFromGroup(student.id, labwork.id, group.id).failed) { error =>
+        error.getMessage shouldBe s"student ${student.id} is not a member of group ${group.id}"
+      }
+    }
+
+    "fail removing a student from an existing group if he has no valid application" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var group = groups.find(_.labwork == labwork.id).get
+      group = group.copy(members = group.members + student.id)
+      groups = groups.map(g => if (g.id == group.id) group else g)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+
+      async(dao.removeStudentFromGroup(student.id, labwork.id, group.id).failed) { error =>
+        error.getMessage shouldBe "Action.withFilter failed" // TODO bad message
+      }
+    }
+
+    "fail removing a student from an existing group if he would be the last one" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var group = groups.find(_.labwork == labwork.id).get
+      group = group.copy(members = Set(student.id))
+      groups = groups.map(g => if (g.id == group.id) group else g)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+
+      async(dao.removeStudentFromGroup(student.id, labwork.id, group.id).failed) { error =>
+        error.getMessage shouldBe "there must be at least one member left after removal"
+      }
+    }
+
+    "move a student into another group by changing the membership and copying reportCardEntries" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var srcGroup = groups.find(_.labwork == labwork.id).get
+      srcGroup = srcGroup.copy(members = srcGroup.members + student.id)
+      groups = groups.map(g => if (g.id == srcGroup.id) srcGroup else g)
+
+      val destGroup = groups.find(g => g.id != srcGroup.id && g.labwork == labwork.id).get
+      val reportCardEntries = createReportCardEntries(groups).map(e => if (e.student == student.id && e.labwork == labwork.id) e.copy(entryTypes = e.entryTypes.map(_.copy(bool = Some(true)))) else e)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+
+      async(dao.moveStudentToGroup(student.id, labwork.id, srcGroup.id, destGroup.id)) {
+        case (deletedGrp, newMembership, srcCards, destCards, updatedCards) =>
+          deletedGrp shouldBe true
+
+          newMembership.student shouldBe student.id
+          newMembership.group shouldBe destGroup.id
+
+          updatedCards should not be empty
+
+          srcCards.zip(destCards).zip(updatedCards).foreach {
+            case ((s, d), u) =>
+              s.id shouldBe u.id
+              d.id should not be u.id
+
+              u.student shouldBe s.student
+              u.labwork shouldBe s.labwork
+              u.entryTypes shouldBe s.entryTypes
+              u.rescheduled shouldBe s.rescheduled
+              u.retry shouldBe s.retry
+
+              u.date shouldBe d.date
+              u.start shouldBe d.start
+              u.end shouldBe d.end
+              u.room shouldBe d.room
+          }
+      }
+    }
+
+    "fail moving a student into another group if src- and dest- reportCardEntries are inconsistent" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var srcGroup = groups.find(_.labwork == labwork.id).get
+      srcGroup = srcGroup.copy(members = srcGroup.members + student.id)
+      groups = groups.map(g => if (g.id == srcGroup.id) srcGroup else g)
+
+      val destGroup = groups.find(g => g.id != srcGroup.id && g.labwork == labwork.id).get
+      val reportCardEntries = createReportCardEntries(groups).filterNot(e => e.labwork == labwork.id && e.student == student.id)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+
+      async(dao.moveStudentToGroup(student.id, labwork.id, srcGroup.id, destGroup.id).failed) { error =>
+        error.getMessage shouldBe "both src- and dest- reportCardEntries must have the same size"
+      }
+    }
+
+    "fail moving a student into another group if he has no group in the first place" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var srcGroup = groups.find(_.labwork == labwork.id).get
+      srcGroup = srcGroup.copy(members = srcGroup.members + student.id)
+      groups = groups.map(g => if (g.id == srcGroup.id) srcGroup else g)
+
+      val destGroup = groups.find(g => g.id != srcGroup.id && g.labwork == labwork.id).get
+      val reportCardEntries = createReportCardEntries(groups)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+
+      async(dao.moveStudentToGroup(student.id, labwork.id, destGroup.id, srcGroup.id).failed) { error =>
+        error.getMessage shouldBe s"student ${student.id} is not a member of group ${destGroup.id}"
+      }
+    }
+
+    "fail moving a student into another group if he would be the last one" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var srcGroup = groups.find(_.labwork == labwork.id).get
+      srcGroup = srcGroup.copy(members = Set(student.id))
+      groups = groups.map(g => if (g.id == srcGroup.id) srcGroup else g)
+
+      val destGroup = groups.find(g => g.id != srcGroup.id && g.labwork == labwork.id).get
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+
+      async(dao.moveStudentToGroup(student.id, labwork.id, srcGroup.id, destGroup.id).failed) { error =>
+        error.getMessage shouldBe "there must be at least one member left after moving"
+      }
+    }
+
+    "fail moving a student into another group if reportCardEntries are not supported" in {
+      val labwork = labworks.head
+      val student = UserDb("", "", "", "", StudentStatus, Some(""), Some(labwork.degree))
+      var groups = createGroups
+      var srcGroup = groups.find(_.labwork == labwork.id).get
+      srcGroup = srcGroup.copy(members = srcGroup.members + student.id)
+      groups = groups.map(g => if (g.id == srcGroup.id) srcGroup else g)
+
+      val destGroup = groups.find(g => g.id != srcGroup.id && g.labwork == labwork.id).get
+      val reportCardEntries = createReportCardEntries(groups).map(e => if (e.assignmentIndex == 1) e.copy(assignmentIndex = -1) else e)
+
+      async(db.run(TableQuery[UserTable].insertOrUpdate(student)))(_ => Unit)
+      async(groupDap.createMany(groups))(_ => Unit)
+      async(reportCardEntryDao.createMany(reportCardEntries))(_ => Unit)
+
+      async(dao.moveStudentToGroup(student.id, labwork.id, srcGroup.id, destGroup.id).failed) { error =>
+        error.getMessage shouldBe "could not copy reportCardEntries because this operation is only supported on cards with a valid assignmentIndex"
+      }
+    }
+  }
+
+  private def createReportCardEntries(groups: List[GroupDb]) = {
+    val reportCardEntries = for {
+      g <- groups
+      s <- g.members
+      e <- (1 until 5).map { i =>
+        val id = UUID.randomUUID
+        val types = (0 until 4).map(i => ReportCardEntryTypeDb(Some(id), None, i.toString)).toSet
+
+        ReportCardEntryDb(s, g.labwork, i.toString, randomLocalDate.sqlDate, randomLocalTime.sqlTime, randomLocalTime.sqlTime, rooms.head.id, types, i, id = id)
+      }
+    } yield e
+    reportCardEntries
+  }
+
+  private def createGroups = {
+    students.grouped(labworks.size).grouped(labworks.size).toList.zip(labworks).zipWithIndex.flatMap {
+      case ((ss, l), i) => ss.map(s => GroupDb(i.toString, l.id, s.map(_.id).toSet))
+    }
+  }
+
+  override protected def bindings: Seq[GuiceableModule] = Seq.empty
+
+  override protected def dependencies: DBIOAction[Unit, NoStream, Effect.Write] = DBIO.seq(
+    TableQuery[RoomTable].forceInsertAll(rooms),
+    TableQuery[DegreeTable].forceInsertAll(degrees),
+    TableQuery[UserTable].forceInsertAll(users),
+    TableQuery[SemesterTable].forceInsertAll(semesters),
+    TableQuery[CourseTable].forceInsertAll(courses),
+    TableQuery[LabworkTable].forceInsertAll(labworks),
+    TableQuery[LabworkApplicationTable].forceInsertAll(applications)
+  )
+}

--- a/test/dao/LwmServiceDaoSpec.scala
+++ b/test/dao/LwmServiceDaoSpec.scala
@@ -3,7 +3,8 @@ package dao
 import java.util.UUID
 
 import base.{DateGenerator, PostgresDbSpec}
-import dao.helper.TableFilter.{userFilter, labworkFilter}
+import dao.helper.NoEntityFound
+import dao.helper.TableFilter.{labworkFilter, userFilter}
 import database._
 import database.helper.LdapUserStatus.StudentStatus
 import play.api.inject.guice.GuiceableModule
@@ -27,7 +28,7 @@ class LwmServiceDaoSpec extends PostgresDbSpec with DateGenerator {
   private val semesters = AbstractDaoSpec.populateSemester(1)
   private val courses = AbstractDaoSpec.populateCourses(1)(_ => 1)
   private val labworks = AbstractDaoSpec.populateLabworks(3)(semesters, courses, degrees)
-  private val applications = AbstractDaoSpec.populateLabworkApplications(students.size, true)(labworks, students)
+  private val applications = AbstractDaoSpec.populateLabworkApplications(students.size, withFriends = true)(labworks, students)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -252,7 +253,7 @@ class LwmServiceDaoSpec extends PostgresDbSpec with DateGenerator {
       async(groupDap.createMany(groups))(_ => Unit)
 
       async(dao.removeStudentFromGroup(student.id, labwork.id, group.id).failed) { error =>
-        error.getMessage shouldBe "Action.withFilter failed" // TODO bad message
+        error.getMessage shouldBe NoEntityFound.getMessage
       }
     }
 

--- a/test/service/BackupServiceSpec.scala
+++ b/test/service/BackupServiceSpec.scala
@@ -4,6 +4,7 @@ import java.io.File
 
 import base.DatabaseSpec
 import dao._
+import models.UniqueEntity
 import org.apache.commons.io.FileUtils
 import org.mockito.Mockito._
 import org.scalatest.TryValues
@@ -18,7 +19,6 @@ import scala.util.Try
 final class BackupServiceSpec extends DatabaseSpec with MockitoSugar with TryValues {
 
   import dao.AbstractDaoSpec._
-  import models.UniqueEntity.toJson
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -38,7 +38,6 @@ final class BackupServiceSpec extends DatabaseSpec with MockitoSugar with TryVal
   val schedules = scheduleEntries.map(_.toUniqueEntity)
   val grps = groups.map(_.toUniqueEntity)
 
-  val jsonSeq = toJson(usr, crs, deg, lapps, labs, rms, sems, cards, auths, schedules, grps)
 
   private val userDao = mock[UserDao]
   private val assignmentPlanDao = mock[AssignmentPlanDao]
@@ -60,6 +59,22 @@ final class BackupServiceSpec extends DatabaseSpec with MockitoSugar with TryVal
   private val backupService = new PSQLBackupService(userDao, assignmentPlanDao, courseDao, degreeDao, labworkApplicationDao,
     labworkDao, roleDao, roomDao, semesterDao, timetableDao, blacklistDao, reportCardEntryDao,
     authorityDao, scheduleEntryDao, groupDao, reportCardEvaluationDao)
+
+  lazy val jsonSeq = Seq(
+    toJson(usr),
+    toJson(crs),
+    toJson(deg),
+    toJson(lapps),
+    toJson(labs),
+    toJson(rms),
+    toJson(sems),
+    toJson(cards),
+    toJson(auths),
+    toJson(schedules),
+    toJson(grps)
+  )
+
+  def toJson(seq: Seq[UniqueEntity]) = backupService.toJson(seq)
 
   private val destFolder = {
     val file = new File("test", "test_dir")


### PR DESCRIPTION
- change default POST operation to create single instead of create many
- http responses should never serialise DB classes
- failure which occur during http request processing are reported as bad requests instead of internal server errors
- AbstractCRUDController specs for fake requests (with fake dao)